### PR TITLE
Add TTS mode to WaveBench

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WaveBench
 
-A terminal-based tool for benchmarking Large Language Models side-by-side via the [OpenRouter](https://openrouter.ai/) API. Send one prompt to multiple models in parallel, compare their generated code or prose, and track lifetime performance analytics from your terminal.
+A terminal-based tool for benchmarking Large Language Models side-by-side via the [OpenRouter](https://openrouter.ai/) API. Send one prompt to multiple models in parallel, compare their generated code, prose, or TTS audio, and track lifetime performance analytics from your terminal.
 
 ## Prerequisites
 
@@ -20,7 +20,7 @@ source .venv/bin/activate   # macOS / Linux
 pip install .
 ```
 
-The only runtime dependency is `aiohttp`.
+The only required runtime dependency is `aiohttp`. WaveBench plays TTS outputs natively through the OS audio backend without launching external apps.
 
 ## Configuration
 
@@ -40,17 +40,20 @@ wavebench
 python -m wavebench
 ```
 
-Interactive startup shows a **Code / Text** mode selector, a summary of active models, and a prompt input with readline-style history. Type `c` at the mode prompt to open the configuration menu.
+Interactive startup shows a **Code / Text / TTS** mode selector, a summary of active models, and a prompt input with readline-style history. Type `c` at the mode prompt to open the configuration menu.
 
 ### CLI Flags
 
 | Flag | Description |
 |---|---|
 | `--prompt "…"` | Skip interactive input and run immediately |
-| `--mode code\|text` | Select the response mode; defaults to `code` |
+| `--mode code\|text\|tts` | Select the response mode; defaults to `code` |
 | `--text` | Alias for `--mode text` |
+| `--tts-voice VOICE` | Voice for TTS mode; defaults to `alloy` for OpenAI models; known non-OpenAI TTS models use provider voices automatically when the default is selected (for example Gemini `Kore`, Zonos `american_female`, Voxtral `en_paul_neutral`) |
+| `--tts-format mp3\|pcm` | Preferred audio format for TTS mode; defaults to `mp3` and is adjusted for providers such as Gemini that require `pcm` |
+| `--tts-speed FLOAT` | TTS playback speed multiplier for providers that support it |
 | `--config` / `--models` | Open the configuration menu and exit after saving/cancelling |
-| `--open incremental\|after_all` / `--auto-open …` | Auto-open generated files as they complete or after all models finish |
+| `--open incremental\|after_all` / `--auto-open …` | Auto-open generated code/text files as they complete or after all models finish; TTS uses the output browser instead |
 | `--auto-install` | In code mode, permit PyPI dependencies and auto-install detected Python packages into a per-run venv before opening files |
 | `--stats` | Display lifetime analytics and exit |
 | `--clear-history` | Reset all analytics history |
@@ -61,6 +64,7 @@ Examples:
 wavebench --prompt "Create a snake game in Python"
 wavebench --prompt "Explain quantum computing" --mode text
 wavebench --prompt "Explain quantum computing" --text
+wavebench --prompt "Read this aloud in a calm tone" --mode tts --tts-voice nova
 wavebench --config
 wavebench --stats
 ```
@@ -68,10 +72,10 @@ wavebench --stats
 ## How It Works
 
 1. **Prompt** — You enter a description of what you want built or answered.
-2. **Mode framing** — The selected mode (`CodeMode` or `TextMode`) wraps the user prompt with mode-specific instructions.
+2. **Mode framing** — The selected mode (`CodeMode`, `TextMode`, or `TTSMode`) prepares the user prompt for the target API.
 3. **Directory naming** — The configured naming mode creates a short directory name from the prompt: either the LLM fallback chain or a local slug parser.
 4. **Parallel execution** — All selected models are queried concurrently, up to `MAX_CONCURRENCY = 12`, with streaming responses and a live progress display.
-5. **Parsing** — Code mode extracts a single savable artifact from JSON, fenced code blocks, malformed fences, or whole-response fallback. Text mode saves raw Markdown.
+5. **Parsing** — Code mode extracts a single savable artifact from JSON, fenced code blocks, malformed fences, or whole-response fallback. Text mode saves raw Markdown. TTS mode saves raw audio bytes from OpenRouter's `/audio/speech` endpoint.
 6. **Results** — Outputs are saved to `benchmarkResults/<prompt_dir>/`; a leaderboard shows pass/fail status, file names, token counts, timing, and estimated cost.
 7. **Analytics** — Every run is recorded and lifetime stats show success rate, average time, token usage, and cost.
 
@@ -79,9 +83,10 @@ wavebench --stats
 
 Open the interactive config menu with `wavebench --config` or by pressing `c` at the startup mode prompt.
 
-The menu has two tabs:
+The menu has three tabs:
 
-- **Models** — Search, browse, and toggle models from the OpenRouter catalog. Models are ranked by provider tier, pricing, recency, supported capabilities, and context length. Press `+` to manually add a model by its OpenRouter ID.
+- **Models** — Search, browse, and toggle non-TTS models from the OpenRouter catalog. Models are ranked by provider tier, pricing, recency, supported capabilities, and context length. Press `+` to manually add a model by its OpenRouter ID.
+- **TTS** — Search, browse, and toggle speech-output models separately from the main model list. If no TTS models are selected, TTS mode falls back to the bundled OpenRouter TTS defaults.
 - **Settings** — Configure:
   - **Reasoning effort** — `max`, `xhigh`, `high`, `medium`, `low`, or `off`. Unsupported values are mapped per model where possible.
   - **Analytics sort** — `runs`, `avg_time`, `rate`, `avg_tokens`, or `cost`.
@@ -89,6 +94,7 @@ The menu has two tabs:
   - **Directory naming** — `llm` for the fast OpenRouter fallback chain, or `slug` for a deterministic local parser.
   - **Auto-open files** — `off`, `incremental`, or `after_all`.
   - **Auto-install deps** — `off` or `on`; shown only when auto-open is enabled. Applies to Python code-mode outputs.
+  - **TTS voice / format / speed** — default voice, audio format, and playback speed for TTS mode. Voice identifiers are provider-specific.
 
 Selections persist across runs in local JSON files.
 
@@ -106,7 +112,7 @@ benchmarkResults/
     └── ...
 ```
 
-In text mode, outputs are saved as `.md` files.
+In text mode, outputs are saved as `.md` files. In TTS mode, outputs are saved as provider-compatible audio files (`.mp3` by default for OpenAI/Voxtral/Zonos and most speech models, `.pcm` for Gemini TTS), then an interactive arrow-key browser lets you move between outputs with ↑/↓ or ←/→ and press Enter/Space to play one through WaveBench's native audio backend.
 
 ## Project Structure
 
@@ -120,7 +126,8 @@ wavebench/
 ├── modes/                      # Response modes and registry
 │   ├── __init__.py             # Mode protocol, ParsedOutput, MODES
 │   ├── code.py                 # CodeMode prompt framing + parser wrapper
-│   └── text.py                 # TextMode prompt framing + Markdown pass-through
+│   ├── text.py                 # TextMode prompt framing + Markdown pass-through
+│   └── tts.py                  # TTSMode prompt framing + audio-byte pass-through
 ├── core/                       # Benchmark orchestration and artifact handling
 │   ├── __init__.py             # Public re-exports
 │   ├── orchestrator.py         # main_async run coordinator
@@ -131,6 +138,7 @@ wavebench/
     ├── styles.py               # Themes, ANSI helpers, box drawing, formatting
     ├── input.py                # Raw keyboard reads
     ├── line_editor.py          # Readline-style prompt editor
+    ├── tts_player.py           # Arrow-key TTS output browser/player
     ├── progress/               # Live progress tracker and wave rendering
     ├── analytics/              # Cost helper and lifetime stats table
     └── menus/                  # Model browser and tabbed config menu
@@ -145,11 +153,11 @@ These are created in the current working directory and are gitignored:
 | File | Contents |
 |---|---|
 | `.benchmark_models.json` | Currently selected `{short_name: openrouter_id}` model mapping |
-| `.benchmark_config.json` | Settings such as theme, reasoning effort, analytics sort, directory naming, auto-open, and auto-install |
+| `.benchmark_config.json` | Settings such as theme, reasoning effort, analytics sort, directory naming, auto-open, auto-install, and TTS voice/format/speed |
 | `.benchmark_history.json` | Lifetime run history for analytics |
 | `.benchmark_query_history` | Readline-style prompt history |
 
-Because state paths are based on `os.getcwd()`, running WaveBench from different directories creates separate project-local state.
+Because state paths are based on `os.getcwd()`, running WaveBench from different directories creates separate project-local state. TTS mode automatically uses selected TTS-capable models, falling back to the bundled TTS defaults when none are selected.
 
 ## Development
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -64,14 +64,15 @@ globally.
 ```text
 wavebench/
 ├── __main__.py                 CLI entry point, interactive startup, dispatch
-├── api.py                      OpenRouter HTTP/SSE client and model catalog fetch
-├── models.py                   default model mapping and catalog scoring
+├── api.py                      OpenRouter HTTP/SSE client, TTS speech, catalog fetch
+├── models.py                   default text/TTS mappings, TTS voice/format helpers, catalog scoring
 ├── parsers.py                  LLM output → code + extension; directory names
 ├── storage.py                  JSON persistence for models/config/history
 ├── modes/                      response-mode protocol and built-ins
 │   ├── __init__.py             Mode, ParsedOutput, MODES registry
 │   ├── code.py                 CodeMode prompt framing + parser wrapper
-│   └── text.py                 TextMode prompt framing + Markdown pass-through
+│   ├── text.py                 TextMode prompt framing + Markdown pass-through
+│   └── tts.py                  TTSMode prompt framing + audio-byte pass-through
 ├── core/                       benchmark run orchestration and artifact handling
 │   ├── orchestrator.py         main_async, concurrency, result display, history
 │   ├── runner.py               run_model and get_unique_filename
@@ -81,6 +82,7 @@ wavebench/
     ├── styles.py               themes, ANSI helpers, boxes, formatting
     ├── input.py                raw key reads
     ├── line_editor.py          prompt editor
+    ├── tts_player.py           arrow-key TTS output browser/player
     ├── progress/               ProgressTracker and wave rendering
     ├── analytics/              display_analytics and compute_cost
     └── menus/                  model browser and configuration menu
@@ -114,7 +116,7 @@ Helpful fixtures in `tests/conftest.py`:
 
 ## Adding a new mode
 
-WaveBench's response modes — currently `CodeMode` and `TextMode` — implement
+WaveBench's response modes — currently `CodeMode`, `TextMode`, and `TTSMode` — implement
 the `Mode` protocol in `wavebench/modes/__init__.py`. A mode captures two
 mode-specific decisions: how to frame the user's prompt, and how to parse the
 raw LLM response into savable content with a file extension.
@@ -147,7 +149,7 @@ To add a new mode, for example `JsonMode`:
        def frame_prompt(self, user_prompt: str) -> str:
            return f"{_SYSTEM_PROMPT_JSON}\n\nSchema: {user_prompt}"
 
-       def parse_response(self, raw: str) -> ParsedOutput:
+       def parse_response(self, raw: str | bytes) -> ParsedOutput:
            text = raw.strip()
            try:
                _json.loads(text)
@@ -183,7 +185,7 @@ To add a new mode, for example `JsonMode`:
 4. **Decide how it appears in the interactive startup UI.** Once registered,
    your mode is automatically accepted by `wavebench --mode json` and appears
    in `wavebench --help`. The interactive startup selector currently displays
-   Code/Text shortcuts explicitly, so update `_print_mode_menu()` and key
+   Code/Text/TTS shortcuts explicitly, so update `_print_mode_menu()` and key
    handling in `wavebench/__main__.py` if the new mode should be selectable
    there too.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ wavebench.__main__
           │
           ▼
     core.orchestrator.main_async
-      ├─ resolves CodeMode/TextMode
+      ├─ resolves CodeMode/TextMode/TTSMode
       ├─ asks parsers.get_directory_name for benchmarkResults/<dir>
       ├─ starts tui.progress.ProgressTracker
       ├─ fans out concurrent core.runner.run_model tasks
@@ -37,15 +37,16 @@ wavebench.__main__
 wavebench/
 ├── __init__.py
 ├── __main__.py                 CLI args, startup UI, state loading, dispatch
-├── api.py                      OpenRouter client, SSE parser, retries, catalog fetch
-├── models.py                   default model mapping, catalog scoring, stealth filter
+├── api.py                      OpenRouter client, SSE parser, TTS speech, retries, catalog fetch
+├── models.py                   default text/TTS mappings, catalog scoring, TTS helpers
 ├── parsers.py                  code extraction and prompt-derived directory names
 ├── storage.py                  JSON persistence for local state and analytics
 │
 ├── modes/
 │   ├── __init__.py             Mode protocol, ParsedOutput, MODES registry
 │   ├── code.py                 CodeMode prompt framing + parser wrapper
-│   └── text.py                 TextMode prompt framing + Markdown pass-through
+│   ├── text.py                 TextMode prompt framing + Markdown pass-through
+│   └── tts.py                  TTSMode prompt framing + audio-byte pass-through
 │
 ├── core/
 │   ├── __init__.py             public re-exports for core package users
@@ -59,6 +60,7 @@ wavebench/
     ├── styles.py               themes, ANSI helpers, box drawing, formatting
     ├── input.py                raw key reads, resize-aware key handling
     ├── line_editor.py          prompt editor with history/navigation
+    ├── tts_player.py           arrow-key TTS output browser/player
     ├── progress/
     │   ├── __init__.py         re-exports ProgressTracker, render_idle_wave
     │   ├── tracker.py          live multi-model progress UI
@@ -71,7 +73,7 @@ wavebench/
         ├── __init__.py         re-exports menu entry points
         ├── _shared.py          price/name/filter/layout helpers
         ├── model_list.py       model catalog browser + selection flow
-        └── config_menu.py      tabbed Models/Settings config menu
+        └── config_menu.py      tabbed Models/TTS/Settings config menu
 ```
 
 ## Current module sizes
@@ -80,10 +82,10 @@ Line counts are approximate and useful mostly for spotting oversized files:
 
 | Module | Lines | Role |
 |---|---:|---|
-| `wavebench/api.py` | 824 | OpenRouter HTTP/SSE client, reasoning-effort negotiation, model catalog |
+| `wavebench/api.py` | 880+ | OpenRouter HTTP/SSE client, TTS speech, reasoning-effort negotiation, model catalog |
 | `wavebench/tui/progress/tracker.py` | 728 | Animated progress tracker and final progress-state rendering |
 | `wavebench/tui/styles.py` | 635 | Theme definitions, ANSI helpers, box drawing, formatting |
-| `wavebench/tui/menus/config_menu.py` | 566 | Interactive tabbed Models/Settings menu |
+| `wavebench/tui/menus/config_menu.py` | 710 | Interactive tabbed Models/TTS/Settings menu |
 | `wavebench/core/orchestrator.py` | 382 | Top-level benchmark run coordinator |
 | `wavebench/__main__.py` | 371 | CLI parsing, startup mode/prompt UI, config dispatch |
 | `wavebench/core/auto_open.py` | 324 | Viewer, terminal, and tab launching |
@@ -114,7 +116,8 @@ Line counts are approximate and useful mostly for spotting oversized files:
 2. **Run setup (`core.orchestrator.main_async`)**
    - Resolves the active mode: explicit `--mode`, then legacy `--text`, then
      code mode by default. Code mode is instantiated with `allow_deps=True`
-     when auto-install is enabled.
+     when auto-install is enabled; TTS mode is instantiated with configured
+     voice/format/speed.
    - Determines default output extension (`.md` for text, `.py` for Python-ish
      prompts, otherwise `.html`).
    - Creates an async task for `parsers.get_directory_name()` so the output
@@ -126,7 +129,7 @@ Line counts are approximate and useful mostly for spotting oversized files:
 3. **Per-model work (`core.runner.run_model`)**
    - Calls `mode.frame_prompt(user_prompt)`.
    - Streams from OpenRouter through `api.call_model_streaming()` with progress
-     and retry callbacks.
+     and retry callbacks, or calls `api.call_tts_speech()` for TTS audio bytes.
    - Passes the raw response to `mode.parse_response()`.
    - Creates a unique filename with `get_unique_filename()` and writes the
      parsed content into `benchmarkResults/<prompt_dir>/`.
@@ -134,6 +137,9 @@ Line counts are approximate and useful mostly for spotting oversized files:
      detects packages, ensures a `.venv` in the output directory, and installs
      packages before opening.
    - If `auto_open == "incremental"`, opens the artifact as soon as it is saved.
+   - In TTS mode, successful audio artifacts can be browsed with arrow keys and
+     played through WaveBench's native audio backend with Enter/Space in the
+     post-run `tui.tts_player` screen, without launching an external app.
 
 4. **Finish / reporting (`core.orchestrator.main_async`)**
    - For `auto_open == "after_all"`, opens all successful artifacts after every
@@ -163,11 +169,12 @@ The package intentionally re-exports common entry points from package
 | If you want to change… | Start here |
 |---|---|
 | CLI flags, startup mode selection, prompt history | `wavebench/__main__.py` |
-| OpenRouter request/response behavior, retries, SSE parsing | `wavebench/api.py` |
+| OpenRouter request/response behavior, retries, SSE parsing, TTS speech | `wavebench/api.py` |
 | Reasoning-effort payload formats and per-model effort mapping | `wavebench/api.py` (`_reasoning_attempts`, `_supported_efforts`) |
-| Model catalog ranking and default model selection | `wavebench/models.py` |
+| Model catalog ranking, default text/TTS mappings, and TTS model/voice/format helpers | `wavebench/models.py` |
 | Code extraction from model responses | `wavebench/parsers.py` and `wavebench/modes/code.py` |
 | Adding a new response mode | `wavebench/modes/` and the guide in `docs/CONTRIBUTING.md` |
+| TTS output navigation/playback | `wavebench/tui/tts_player.py` |
 | Benchmark fan-out, output directory setup, history recording | `wavebench/core/orchestrator.py` |
 | Per-model file writing and parse-failure handling | `wavebench/core/runner.py` |
 | Auto-open terminal/viewer behavior | `wavebench/core/auto_open.py` |
@@ -189,6 +196,12 @@ Modes are small value objects implementing `wavebench.modes.Mode`:
   so the prompt permits PyPI packages.
 - `TextMode` frames prompts for Markdown prose and saves the raw response as
   `.md`.
+- `TTSMode` sends the user text to OpenRouter's `/audio/speech` endpoint,
+  saves returned audio bytes with provider-compatible extensions (`.mp3` by default
+  for OpenAI/Voxtral/Zonos and most speech models, `.pcm` for Gemini TTS), maps
+  known non-OpenAI defaults to provider voices such as Gemini `Kore`, Zonos
+  `american_female`, Voxtral `en_paul_neutral`, and Kokoro `af_alloy`, and plays
+  saved outputs through the native TTS player without launching an external app.
 
 A mode must provide:
 
@@ -207,8 +220,8 @@ WaveBench stores local state in the current working directory:
 
 | File | Contents |
 |---|---|
-| `.benchmark_models.json` | selected `{short_name: openrouter_id}` mapping |
-| `.benchmark_config.json` | `reasoning_effort`, `analytics_sort`, `theme`, `directory_naming`, `auto_open`, `auto_install` |
+| `.benchmark_models.json` | selected `{short_name: openrouter_id}` mapping; TTS mode filters this to TTS-capable IDs and falls back to bundled TTS defaults if none are selected |
+| `.benchmark_config.json` | `reasoning_effort`, `analytics_sort`, `theme`, `directory_naming`, `auto_open`, `auto_install`, `tts_voice`, `tts_format`, `tts_speed` |
 | `.benchmark_history.json` | `{version: 1, runs: [...]}` analytics history |
 | `.benchmark_query_history` | prompt-entry history for the interactive editor |
 

--- a/tests/characterization/test_menus_contract.py
+++ b/tests/characterization/test_menus_contract.py
@@ -198,6 +198,63 @@ def test_line_editor_module_exports_read_line_and_tabescape() -> None:
     assert issubclass(_TabEscape, Exception)
 
 
+def test_config_menu_builds_separate_default_model_tabs() -> None:
+    from wavebench.models import MODEL_MAPPING, TTS_MODEL_MAPPING
+    from wavebench.tui.menus.config_menu import (
+        _build_config_model_items,
+        _filter_config_model_indices,
+    )
+
+    items = _build_config_model_items([], {}, {})
+    normal_ids = {items[i]["id"] for i in _filter_config_model_indices(items, "", tts=False)}
+    tts_ids = {items[i]["id"] for i in _filter_config_model_indices(items, "", tts=True)}
+
+    assert set(MODEL_MAPPING.values()).issubset(normal_ids)
+    assert set(TTS_MODEL_MAPPING.values()).issubset(tts_ids)
+    assert normal_ids.isdisjoint(tts_ids)
+
+
+def test_config_menu_seeds_tts_defaults_when_current_mapping_has_only_text() -> None:
+    from wavebench.models import TTS_MODEL_MAPPING
+    from wavebench.tui.menus.config_menu import (
+        _build_config_model_items,
+        _filter_config_model_indices,
+    )
+
+    items = _build_config_model_items(
+        [], {"claude": "anthropic/claude-opus-4.6"}, pricing_lookup={}
+    )
+    selected_tts_ids = {
+        items[i]["id"]
+        for i in _filter_config_model_indices(items, "", tts=True)
+        if items[i]["selected"]
+    }
+
+    assert set(TTS_MODEL_MAPPING.values()).issubset(selected_tts_ids)
+
+
+def test_config_menu_filters_catalog_models_into_matching_tabs() -> None:
+    from wavebench.tui.menus.config_menu import (
+        _build_config_model_items,
+        _filter_config_model_indices,
+    )
+
+    items = _build_config_model_items(
+        [
+            {"id": "anthropic/claude-opus-4.6"},
+            {"id": "google/gemini-3.1-flash-tts-preview"},
+        ],
+        {},
+        pricing_lookup={},
+    )
+
+    normal_matches = [items[i]["id"] for i in _filter_config_model_indices(items, "claude", tts=False)]
+    tts_matches = [items[i]["id"] for i in _filter_config_model_indices(items, "tts", tts=True)]
+
+    assert normal_matches == ["anthropic/claude-opus-4.6"]
+    assert "google/gemini-3.1-flash-tts-preview" in tts_matches
+
+
 def test_menus_package_exports_public_entries() -> None:
     from wavebench.tui.menus import (
         interactive_config_menu,

--- a/tests/characterization/test_progress_contract.py
+++ b/tests/characterization/test_progress_contract.py
@@ -53,6 +53,14 @@ def test_compute_cost_returns_none_for_zero_cost() -> None:
     assert compute_cost(usage, pricing) is None
 
 
+def test_compute_cost_handles_tts_input_characters() -> None:
+    from wavebench.tui.analytics import compute_cost
+
+    usage = {"input_characters": 120}
+    pricing = {"prompt": "0.000001", "request": "0.01"}
+    assert compute_cost(usage, pricing) == pytest.approx(120 * 0.000001 + 0.01)
+
+
 def test_compute_cost_handles_invalid_pricing_strings() -> None:
     from wavebench.tui.analytics import compute_cost
 
@@ -107,6 +115,34 @@ def test_progress_tracker_constructs_with_minimal_args() -> None:
     tracker = ProgressTracker(total=3, results={})
     assert tracker.is_running is False
     assert tracker.rendered_final is False
+
+
+def test_progress_tracker_accepts_byte_progress_unit() -> None:
+    from wavebench.tui.progress import ProgressTracker
+
+    tracker = ProgressTracker(total=1, results={}, progress_unit="bytes")
+    tracker.register("tts_model")
+    tracker.update("tts_model", 4096)
+    tracker.unregister("tts_model")
+
+
+def test_progress_tracker_result_row_formats_audio_bytes() -> None:
+    from wavebench.tui.progress import ProgressTracker
+
+    tracker = ProgressTracker(total=1, results={})
+    row = tracker._format_result_row(
+        "tts_model",
+        {
+            "status": "success",
+            "time_s": 1.0,
+            "file": "tts_model.mp3",
+            "usage": {"audio_bytes": 4096},
+        },
+        rank=1,
+        inner_w=100,
+    )
+
+    assert "4.0 KiB" in row
 
 
 def test_progress_tracker_register_update_unregister() -> None:

--- a/tests/integration/test_api_streaming.py
+++ b/tests/integration/test_api_streaming.py
@@ -189,6 +189,203 @@ async def test_streaming_http_error_raises_runtime_error(
 
 
 # ---------------------------------------------------------------------------
+# TTS audio endpoint
+# ---------------------------------------------------------------------------
+
+
+async def test_tts_speech_posts_audio_request_and_returns_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
+
+    async def handler(request: web.Request) -> web.Response:
+        seen["body"] = await request.json()
+        return web.Response(
+            body=b"ID3audio",
+            headers={"Content-Type": "audio/mpeg", "X-Generation-Id": "gen_123"},
+        )
+
+    app = web.Application()
+    app.router.add_post("/audio/speech", handler)
+
+    async with _running_server(app) as server:
+        monkeypatch.setattr(api_mod, "API_URL", str(server.make_url("")).rstrip("/"))
+        async with aiohttp.ClientSession() as session:
+            audio, usage = await api_mod.call_tts_speech(
+                session,
+                api_key="test-key",
+                model_id="openai/test-tts",
+                input_text="Hello",
+                voice="nova",
+                response_format="mp3",
+                speed=1.25,
+            )
+
+    assert audio == b"ID3audio"
+    assert seen["body"] == {
+        "model": "openai/test-tts",
+        "input": "Hello",
+        "voice": "nova",
+        "response_format": "mp3",
+        "speed": 1.25,
+    }
+    assert usage == {"input_characters": 5, "audio_bytes": 8, "generation_id": "gen_123"}
+
+
+async def test_tts_speech_retries_429_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(api_mod, "_retry_wait_seconds", lambda h, a: 0.0)
+
+    call_log: list[int] = []
+
+    async def handler(request: web.Request) -> web.Response:
+        if len(call_log) < 2:
+            call_log.append(429)
+            return web.Response(status=429, text="upstream throttled")
+        call_log.append(200)
+        return web.Response(body=b"ID3audio", headers={"Content-Type": "audio/mpeg"})
+
+    retries: list[tuple[int, int, int, float]] = []
+    app = web.Application()
+    app.router.add_post("/audio/speech", handler)
+
+    async with _running_server(app) as server:
+        monkeypatch.setattr(api_mod, "API_URL", str(server.make_url("")).rstrip("/"))
+        async with aiohttp.ClientSession() as session:
+            audio, usage = await api_mod.call_tts_speech(
+                session,
+                api_key="test-key",
+                model_id="openai/test-tts",
+                input_text="Hello",
+                on_retry=lambda *args: retries.append(args),
+            )
+
+    assert audio == b"ID3audio"
+    assert usage["audio_bytes"] == 8
+    assert call_log == [429, 429, 200]
+    assert [r[0] for r in retries] == [429, 429]
+    assert [r[1] for r in retries] == [1, 2]
+
+
+async def test_tts_speech_reports_byte_progress(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def handler(request: web.Request) -> web.StreamResponse:
+        resp = web.StreamResponse(status=200, headers={"Content-Type": "audio/mpeg"})
+        await resp.prepare(request)
+        await resp.write(b"abc")
+        await resp.write(b"defg")
+        await resp.write_eof()
+        return resp
+
+    progress_updates: list[int] = []
+    app = web.Application()
+    app.router.add_post("/audio/speech", handler)
+
+    async with _running_server(app) as server:
+        monkeypatch.setattr(api_mod, "API_URL", str(server.make_url("")).rstrip("/"))
+        async with aiohttp.ClientSession() as session:
+            audio, _ = await api_mod.call_tts_speech(
+                session,
+                api_key="test-key",
+                model_id="openai/test-tts",
+                input_text="Hello",
+                on_progress=progress_updates.append,
+            )
+
+    assert audio == b"abcdefg"
+    assert progress_updates[-1] == len(audio)
+    assert all(a <= b for a, b in pairwise(progress_updates))
+
+
+async def test_tts_speech_http_error_raises_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(status=400, text='{"error":"bad voice"}')
+
+    app = web.Application()
+    app.router.add_post("/audio/speech", handler)
+
+    async with _running_server(app) as server:
+        monkeypatch.setattr(api_mod, "API_URL", str(server.make_url("")).rstrip("/"))
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(RuntimeError, match="HTTP 400"):
+                await api_mod.call_tts_speech(
+                    session,
+                    api_key="test-key",
+                    model_id="openai/test-tts",
+                    input_text="Hello",
+                )
+
+
+# ---------------------------------------------------------------------------
+# Model catalog fetch
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_top_models_includes_reserved_speech_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested_urls: list[str] = []
+
+    def model(mid: str, output_modalities: list[str]) -> dict:
+        return {
+            "id": mid,
+            "canonical_slug": mid,
+            "name": mid,
+            "created": 0,
+            "architecture": {
+                "input_modalities": ["text"],
+                "output_modalities": output_modalities,
+            },
+            "pricing": {"prompt": "0.000001", "completion": "0.000001"},
+            "supported_parameters": [],
+            "context_length": 8192,
+        }
+
+    body = {
+        "data": [
+            model("provider/text-a", ["text"]),
+            model("provider/text-b", ["text"]),
+            model("provider/text-c", ["text"]),
+            model("openai/gpt-4o-mini-tts-2025-12-15", ["speech"]),
+            model("mistralai/voxtral-mini-tts-2603", ["speech"]),
+            model("provider/image", ["image"]),
+            model("provider/audio", ["audio"]),
+        ]
+    }
+
+    class FakeResponse:
+        def __enter__(self) -> FakeResponse:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps(body).encode()
+
+    def fake_urlopen(req: object, timeout: int) -> FakeResponse:
+        requested_urls.append(req.full_url)  # type: ignore[attr-defined]
+        assert timeout == 15
+        return FakeResponse()
+
+    monkeypatch.setattr(api_mod.urllib.request, "urlopen", fake_urlopen)
+
+    models, pricing = api_mod.fetch_top_models("test-key", count=3)
+
+    ids = [m["id"] for m in models]
+    assert requested_urls == [f"{api_mod.API_URL}/models?output_modalities=all"]
+    assert len(ids) == 3
+    assert "openai/gpt-4o-mini-tts-2025-12-15" in ids
+    assert "mistralai/voxtral-mini-tts-2603" in ids
+    assert not {"provider/image", "provider/audio"} & set(ids)
+    assert "provider/image" in pricing  # pricing lookup still covers all models
+
+
+# ---------------------------------------------------------------------------
 # Pure helpers in api.py that don't need a server
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_main_cli_tts.py
+++ b/tests/unit/test_main_cli_tts.py
@@ -1,0 +1,60 @@
+"""CLI-entry coverage for TTS mode selection."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+
+def _default_config() -> dict[str, Any]:
+    return {
+        "reasoning_effort": "high",
+        "analytics_sort": "runs",
+        "theme": "default",
+        "auto_open": "off",
+        "auto_install": "off",
+        "directory_naming": "llm",
+        "tts_voice": "alloy",
+        "tts_format": "mp3",
+        "tts_speed": 1.0,
+    }
+
+
+def test_mode_tts_flag_skips_interactive_mode_selector(monkeypatch) -> None:
+    from wavebench import __main__ as main_mod
+
+    seen: dict[str, Any] = {}
+
+    async def fake_main_async(args, api_key, model_mapping=None, config=None, pricing_lookup=None):
+        seen["prompt"] = args.prompt
+        seen["mode"] = args.mode
+        seen["text"] = args.text
+        seen["api_key"] = api_key
+
+    def fail_if_mode_selector_reads_key(_timeout: float):
+        raise AssertionError("mode selector should be skipped when --mode is provided")
+
+    monkeypatch.setattr(sys, "argv", ["wavebench", "--mode", "tts"])
+    monkeypatch.setattr(main_mod, "load_api_key", lambda: "test-key")
+    monkeypatch.setattr(main_mod, "fetch_top_models", lambda *_args, **_kwargs: ([], {}))
+    monkeypatch.setattr(main_mod, "load_models", lambda: None)
+    monkeypatch.setattr(main_mod, "load_config", _default_config)
+    monkeypatch.setattr(main_mod, "apply_theme", lambda _theme: None)
+    monkeypatch.setattr(main_mod, "_load_query_history", lambda: None)
+    monkeypatch.setattr(main_mod, "_save_query_history", lambda _query: None)
+    monkeypatch.setattr(main_mod, "_read_key_timeout", fail_if_mode_selector_reads_key)
+    monkeypatch.setattr(
+        main_mod,
+        "_read_line",
+        lambda _prompt, history=None, on_idle=None: "Hello from WaveBench",
+    )
+    monkeypatch.setattr(main_mod, "main_async", fake_main_async)
+
+    main_mod.main()
+
+    assert seen == {
+        "prompt": "Hello from WaveBench",
+        "mode": "tts",
+        "text": False,
+        "api_key": "test-key",
+    }

--- a/tests/unit/test_models_scoring.py
+++ b/tests/unit/test_models_scoring.py
@@ -236,11 +236,17 @@ def test_tts_voice_for_model_maps_default_to_provider_voice(
     assert tts_voice_for_model(model_id, "alloy") == expected_voice
 
 
-def test_tts_response_format_for_model_uses_provider_supported_format() -> None:
+def test_tts_response_format_for_model_maps_default_to_provider_supported_format() -> None:
     assert tts_response_format_for_model("google/gemini-3.1-flash-tts-preview", "mp3") == "pcm"
-    assert tts_response_format_for_model("mistralai/voxtral-mini-tts-2603", "pcm") == "mp3"
-    assert tts_response_format_for_model("zyphra/zonos-v0.1-hybrid", "pcm") == "mp3"
+    assert tts_response_format_for_model("mistralai/voxtral-mini-tts-2603", "mp3") == "mp3"
+    assert tts_response_format_for_model("zyphra/zonos-v0.1-hybrid", "mp3") == "mp3"
     assert tts_response_format_for_model("openai/gpt-4o-mini-tts-2025-12-15", "mp3") == "mp3"
+
+
+def test_tts_response_format_for_model_preserves_explicit_format() -> None:
+    assert tts_response_format_for_model("google/gemini-3.1-flash-tts-preview", "wav") == "wav"
+    assert tts_response_format_for_model("mistralai/voxtral-mini-tts-2603", "pcm") == "pcm"
+    assert tts_response_format_for_model("zyphra/zonos-v0.1-hybrid", "pcm") == "pcm"
 
 
 def test_tts_voice_for_model_preserves_explicit_voice() -> None:

--- a/tests/unit/test_models_scoring.py
+++ b/tests/unit/test_models_scoring.py
@@ -23,8 +23,12 @@ from wavebench.models import (
     _TIER1_PROVIDERS,
     _TIER2_PROVIDERS,
     MODEL_MAPPING,
+    TTS_MODEL_MAPPING,
     _model_score,
     is_stealth,
+    is_tts_model,
+    tts_response_format_for_model,
+    tts_voice_for_model,
 )
 
 # A ``created`` timestamp 5 years in the past — well past any recency bonus
@@ -184,6 +188,68 @@ def test_context_length_below_32k_gets_no_bonus() -> None:
 
 
 # ---------------------------------------------------------------------------
+# TTS model classification
+# ---------------------------------------------------------------------------
+
+
+def test_is_tts_model_detects_tts_slugs() -> None:
+    assert is_tts_model("openai/gpt-4o-mini-tts-2025-12-15")
+    assert is_tts_model("mistralai/voxtral-mini-tts-2603")
+    assert is_tts_model("vendor/speech-synth")
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "google/gemini-3.1-flash-tts-preview",
+        "zyphra/zonos-v0.1-transformer",
+        "zyphra/zonos-v0.1-hybrid",
+        "sesame/csm-1b",
+        "canopylabs/orpheus-3b-0.1-ft",
+        "hexgrad/kokoro-82m",
+    ],
+)
+def test_is_tts_model_detects_current_openrouter_speech_models(model_id: str) -> None:
+    assert is_tts_model(model_id)
+
+
+def test_is_tts_model_false_for_text_model() -> None:
+    assert not is_tts_model("anthropic/claude-opus-4.6")
+
+
+@pytest.mark.parametrize(
+    ("model_id", "expected_voice"),
+    [
+        ("google/gemini-3.1-flash-tts-preview", "Kore"),
+        ("mistralai/voxtral-mini-tts-2603", "en_paul_neutral"),
+        ("zyphra/zonos-v0.1-hybrid", "american_female"),
+        ("zyphra/zonos-v0.1-transformer", "american_female"),
+        ("sesame/csm-1b", "conversational_a"),
+        ("canopylabs/orpheus-3b-0.1-ft", "tara"),
+        ("hexgrad/kokoro-82m", "af_alloy"),
+    ],
+)
+def test_tts_voice_for_model_maps_default_to_provider_voice(
+    model_id: str,
+    expected_voice: str,
+) -> None:
+    assert tts_voice_for_model(model_id, "alloy") == expected_voice
+
+
+def test_tts_response_format_for_model_uses_provider_supported_format() -> None:
+    assert tts_response_format_for_model("google/gemini-3.1-flash-tts-preview", "mp3") == "pcm"
+    assert tts_response_format_for_model("mistralai/voxtral-mini-tts-2603", "pcm") == "mp3"
+    assert tts_response_format_for_model("zyphra/zonos-v0.1-hybrid", "pcm") == "mp3"
+    assert tts_response_format_for_model("openai/gpt-4o-mini-tts-2025-12-15", "mp3") == "mp3"
+
+
+def test_tts_voice_for_model_preserves_explicit_voice() -> None:
+    assert tts_voice_for_model("google/gemini-3.1-flash-tts-preview", "Puck") == "Puck"
+    assert tts_voice_for_model("mistralai/voxtral-mini-tts-2603", "gb_oliver_neutral") == "gb_oliver_neutral"
+    assert tts_voice_for_model("openai/gpt-4o-mini-tts-2025-12-15", "nova") == "nova"
+
+
+# ---------------------------------------------------------------------------
 # MODEL_MAPPING sanity
 # ---------------------------------------------------------------------------
 
@@ -195,6 +261,16 @@ def test_model_mapping_has_expected_shape() -> None:
     for short_name, full_id in MODEL_MAPPING.items():
         assert isinstance(short_name, str) and short_name
         assert isinstance(full_id, str) and "/" in full_id
+
+
+def test_tts_model_mapping_has_expected_shape() -> None:
+    assert isinstance(TTS_MODEL_MAPPING, dict)
+    assert len(TTS_MODEL_MAPPING) > 0
+    assert TTS_MODEL_MAPPING["voxtralMiniTts2603"] == "mistralai/voxtral-mini-tts-2603"
+    for short_name, full_id in TTS_MODEL_MAPPING.items():
+        assert isinstance(short_name, str) and short_name
+        assert isinstance(full_id, str) and "/" in full_id
+        assert is_tts_model(full_id)
 
 
 def test_tier_sets_are_disjoint() -> None:

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 
 import pytest
 
-from wavebench.modes import CODE_MODE, MODES, TEXT_MODE, ParsedOutput
+from wavebench.modes import CODE_MODE, MODES, TEXT_MODE, TTS_MODE, ParsedOutput
 from wavebench.modes.code import CodeMode
 from wavebench.modes.text import TextMode
+from wavebench.modes.tts import TTSMode
 
 # ---------------------------------------------------------------------------
 # Registry
@@ -22,12 +23,13 @@ from wavebench.modes.text import TextMode
 
 
 def test_registry_contains_both_builtins() -> None:
-    assert set(MODES.keys()) == {"code", "text"}
+    assert set(MODES.keys()) == {"code", "text", "tts"}
 
 
 def test_registry_maps_name_to_canonical_instance() -> None:
     assert MODES["code"] is CODE_MODE
     assert MODES["text"] is TEXT_MODE
+    assert MODES["tts"] is TTS_MODE
 
 
 def test_code_mode_defaults_disallow_deps() -> None:
@@ -39,6 +41,8 @@ def test_mode_identity_attrs() -> None:
     assert CODE_MODE.display_name == "Code"
     assert TEXT_MODE.name == "text"
     assert TEXT_MODE.display_name == "Text"
+    assert TTS_MODE.name == "tts"
+    assert TTS_MODE.display_name == "TTS"
 
 
 # ---------------------------------------------------------------------------
@@ -185,6 +189,39 @@ def test_text_mode_parse_whitespace_returns_failure() -> None:
 
 
 # ---------------------------------------------------------------------------
+# TTSMode
+# ---------------------------------------------------------------------------
+
+
+def test_tts_mode_frame_prompt_preserves_text_to_synthesize() -> None:
+    framed = TTS_MODE.frame_prompt("  Hello from WaveBench.  ")
+    assert framed == "Hello from WaveBench."
+
+
+def test_tts_mode_parse_audio_bytes() -> None:
+    out = TTS_MODE.parse_response(b"ID3audio")
+    assert out.parse_ok is True
+    assert out.content == b"ID3audio"
+    assert out.extension == "mp3"
+    assert out.parse_error is None
+
+
+def test_tts_mode_parse_empty_audio_returns_failure() -> None:
+    out = TTS_MODE.parse_response(b"")
+    assert out.parse_ok is False
+    assert out.extension == "mp3"
+    assert out.parse_error == "empty audio response"
+
+
+def test_tts_mode_can_configure_voice_and_format() -> None:
+    mode = TTSMode(voice="nova", response_format="pcm", speed=1.2)
+    out = mode.parse_response(b"\x00\x01")
+    assert mode.voice == "nova"
+    assert mode.speed == 1.2
+    assert out.extension == "pcm"
+
+
+# ---------------------------------------------------------------------------
 # Cross-mode: independence of registry default from runtime instances
 # ---------------------------------------------------------------------------
 
@@ -199,3 +236,8 @@ def test_construct_deps_variant_without_touching_registry() -> None:
 def test_text_mode_singleton_identity() -> None:
     assert MODES["text"] is TEXT_MODE
     assert isinstance(TEXT_MODE, TextMode)
+
+
+def test_tts_mode_singleton_identity() -> None:
+    assert MODES["tts"] is TTS_MODE
+    assert isinstance(TTS_MODE, TTSMode)

--- a/tests/unit/test_orchestrator_tts.py
+++ b/tests/unit/test_orchestrator_tts.py
@@ -1,0 +1,109 @@
+"""Unit coverage for TTS-specific orchestration decisions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from wavebench.core import orchestrator as orchestrator_mod
+from wavebench.modes.tts import TTSMode
+
+
+def test_resolve_tts_mode_uses_cli_options_over_config() -> None:
+    args = SimpleNamespace(
+        mode="tts",
+        text=False,
+        tts_voice="nova",
+        tts_format="pcm",
+        tts_speed=1.25,
+    )
+
+    mode = orchestrator_mod._resolve_mode(
+        args,
+        auto_install="off",
+        config={"tts_voice": "alloy", "tts_format": "mp3", "tts_speed": 1.0},
+    )
+
+    assert isinstance(mode, TTSMode)
+    assert mode.voice == "nova"
+    assert mode.response_format == "pcm"
+    assert mode.speed == 1.25
+
+
+async def test_main_async_tts_filters_selected_models_to_tts(
+    tmp_state_dir: Path,
+    monkeypatch,
+) -> None:
+    async def fake_get_directory_name(*_args: Any, **_kwargs: Any) -> str:
+        return "tts_outputs"
+
+    seen: list[tuple[str, str, str, str | None, str]] = []
+
+    async def fake_run_model(
+        mode,
+        session,
+        api_key,
+        name,
+        mid,
+        user_prompt,
+        default_ext,
+        output_dir_task,
+        semaphore,
+        results,
+        pad,
+        tracker,
+        reasoning_effort="high",
+        auto_open="off",
+        auto_install="off",
+    ) -> None:
+        seen.append((mode.name, name, mid, reasoning_effort, auto_open))
+        output_dir = await output_dir_task
+        filename = f"{name}{default_ext}"
+        Path(output_dir, filename).write_bytes(b"audio")
+        results[name] = {
+            "status": "success",
+            "time_s": 0.01,
+            "file": filename,
+            "usage": {"audio_bytes": 5, "input_characters": len(user_prompt)},
+            "retries": [],
+        }
+
+    monkeypatch.setattr(orchestrator_mod, "get_directory_name", fake_get_directory_name)
+    monkeypatch.setattr(orchestrator_mod, "run_model", fake_run_model)
+    monkeypatch.setattr(orchestrator_mod, "_open_with_viewer", lambda _path: None)
+
+    args = SimpleNamespace(
+        prompt="Hello from WaveBench",
+        mode="tts",
+        text=False,
+        auto_open=None,
+        auto_install=None,
+        tts_voice=None,
+        tts_format=None,
+        tts_speed=None,
+    )
+    mapping = {
+        "textModel": "anthropic/claude-opus-4.6",
+        "voiceModel": "openai/gpt-4o-mini-tts-2025-12-15",
+    }
+
+    await orchestrator_mod.main_async(
+        args,
+        api_key="test-key",
+        model_mapping=mapping,
+        config={
+            "reasoning_effort": "high",
+            "analytics_sort": "runs",
+            "auto_open": "after_all",
+            "auto_install": "off",
+            "directory_naming": "slug",
+            "tts_voice": "nova",
+            "tts_format": "pcm",
+            "tts_speed": 1.2,
+        },
+        pricing_lookup={},
+    )
+
+    assert seen == [("tts", "voiceModel", "openai/gpt-4o-mini-tts-2025-12-15", None, "off")]
+    assert (tmp_state_dir / "benchmarkResults" / "tts_outputs" / "voiceModel.pcm").read_bytes() == b"audio"

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -50,11 +50,21 @@ def test_wavebench_storage_public_names() -> None:
 
 
 def test_wavebench_models_public_names() -> None:
-    from wavebench.models import MODEL_MAPPING, _model_score, is_stealth
+    from wavebench.models import (
+        MODEL_MAPPING,
+        TTS_MODEL_MAPPING,
+        _model_score,
+        is_stealth,
+        is_tts_model,
+        tts_voice_for_model,
+    )
 
     assert isinstance(MODEL_MAPPING, dict)
+    assert isinstance(TTS_MODEL_MAPPING, dict)
     assert callable(_model_score)
     assert callable(is_stealth)
+    assert callable(is_tts_model)
+    assert callable(tts_voice_for_model)
 
 
 def test_wavebench_api_public_names() -> None:
@@ -63,6 +73,7 @@ def test_wavebench_api_public_names() -> None:
         _supported_efforts,
         call_model_async,
         call_model_streaming,
+        call_tts_speech,
         fetch_top_models,
         load_api_key,
     )
@@ -70,6 +81,7 @@ def test_wavebench_api_public_names() -> None:
     for fn in (
         call_model_async,
         call_model_streaming,
+        call_tts_speech,
         fetch_top_models,
         load_api_key,
         _map_effort,

--- a/tests/unit/test_runner_tts.py
+++ b/tests/unit/test_runner_tts.py
@@ -1,0 +1,161 @@
+"""Unit coverage for TTS-specific runner behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from wavebench.core import runner as runner_mod
+from wavebench.modes.tts import TTSMode
+
+
+class _NoopTracker:
+    is_running = False
+
+
+async def test_run_model_writes_tts_audio_bytes(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    async def fake_call_tts_speech(
+        session: Any,
+        api_key: str,
+        model_id: str,
+        input_text: str,
+        voice: str,
+        response_format: str,
+        speed: float,
+        on_progress: Any,
+        on_retry: Any,
+    ) -> tuple[bytes, dict]:
+        assert model_id == "openai/test-tts"
+        assert input_text == "Hello from WaveBench"
+        assert voice == "nova"
+        assert response_format == "mp3"
+        assert speed == 1.1
+        if on_progress:
+            on_progress(8)
+        return b"ID3audio", {"audio_bytes": 8, "input_characters": len(input_text)}
+
+    monkeypatch.setattr(runner_mod, "call_tts_speech", fake_call_tts_speech)
+
+    async def output_dir() -> str:
+        return str(tmp_path)
+
+    output_dir_task = asyncio.create_task(output_dir())
+    results: dict[str, Any] = {}
+
+    await runner_mod.run_model(
+        TTSMode(voice="nova", response_format="mp3", speed=1.1),
+        session=object(),  # type: ignore[arg-type]
+        api_key="test-key",
+        model_name="voiceModel",
+        model_id="openai/test-tts",
+        user_prompt="Hello from WaveBench",
+        default_ext=".mp3",
+        output_dir_task=output_dir_task,
+        semaphore=asyncio.Semaphore(1),
+        results=results,
+        pad=12,
+        tracker=_NoopTracker(),
+        reasoning_effort=None,
+    )
+
+    assert (tmp_path / "voiceModel.mp3").read_bytes() == b"ID3audio"
+    assert results["voiceModel"]["status"] == "success"
+    assert results["voiceModel"]["file"] == "voiceModel.mp3"
+    assert results["voiceModel"]["usage"]["audio_bytes"] == 8
+
+
+async def test_run_model_maps_default_tts_options_for_bundled_non_openai_models(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    seen: list[tuple[str, str, str]] = []
+
+    async def fake_call_tts_speech(
+        session: Any,
+        api_key: str,
+        model_id: str,
+        input_text: str,
+        voice: str,
+        response_format: str,
+        speed: float,
+        on_progress: Any,
+        on_retry: Any,
+    ) -> tuple[bytes, dict]:
+        seen.append((model_id, voice, response_format))
+        return b"audio", {"audio_bytes": 5, "input_characters": len(input_text)}
+
+    monkeypatch.setattr(runner_mod, "call_tts_speech", fake_call_tts_speech)
+
+    async def output_dir() -> str:
+        return str(tmp_path)
+
+    results: dict[str, Any] = {}
+    output_dir_task = asyncio.create_task(output_dir())
+    await runner_mod.run_model(
+        TTSMode(),
+        session=object(),  # type: ignore[arg-type]
+        api_key="test-key",
+        model_name="geminiTTS",
+        model_id="google/gemini-3.1-flash-tts-preview",
+        user_prompt="Hello",
+        default_ext=".mp3",
+        output_dir_task=output_dir_task,
+        semaphore=asyncio.Semaphore(1),
+        results=results,
+        pad=12,
+        tracker=_NoopTracker(),
+        reasoning_effort=None,
+    )
+
+    assert seen == [("google/gemini-3.1-flash-tts-preview", "Kore", "pcm")]
+    assert results["geminiTTS"]["file"] == "geminiTTS.pcm"
+
+
+async def test_run_model_maps_default_tts_options_for_voxtral(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    seen: list[tuple[str, str, str]] = []
+
+    async def fake_call_tts_speech(
+        session: Any,
+        api_key: str,
+        model_id: str,
+        input_text: str,
+        voice: str,
+        response_format: str,
+        speed: float,
+        on_progress: Any,
+        on_retry: Any,
+    ) -> tuple[bytes, dict]:
+        seen.append((model_id, voice, response_format))
+        return b"ID3audio", {"audio_bytes": 8, "input_characters": len(input_text)}
+
+    monkeypatch.setattr(runner_mod, "call_tts_speech", fake_call_tts_speech)
+
+    async def output_dir() -> str:
+        return str(tmp_path)
+
+    results: dict[str, Any] = {}
+    output_dir_task = asyncio.create_task(output_dir())
+    await runner_mod.run_model(
+        TTSMode(),
+        session=object(),  # type: ignore[arg-type]
+        api_key="test-key",
+        model_name="voxtralMiniTts2603",
+        model_id="mistralai/voxtral-mini-tts-2603",
+        user_prompt="Hello",
+        default_ext=".mp3",
+        output_dir_task=output_dir_task,
+        semaphore=asyncio.Semaphore(1),
+        results=results,
+        pad=20,
+        tracker=_NoopTracker(),
+        reasoning_effort=None,
+    )
+
+    assert seen == [("mistralai/voxtral-mini-tts-2603", "en_paul_neutral", "mp3")]
+    assert results["voxtralMiniTts2603"]["file"] == "voxtralMiniTts2603.mp3"

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -60,6 +60,9 @@ def test_load_config_missing_file_returns_defaults(tmp_state_dir: Path) -> None:
         "auto_open": "off",
         "auto_install": "off",
         "directory_naming": "llm",
+        "tts_voice": "alloy",
+        "tts_format": "mp3",
+        "tts_speed": 1.0,
     }
 
 
@@ -73,6 +76,9 @@ def test_save_config_then_load_config_roundtrip(tmp_state_dir: Path) -> None:
     assert loaded["auto_open"] == "off"
     assert loaded["auto_install"] == "off"
     assert loaded["directory_naming"] == "llm"
+    assert loaded["tts_voice"] == "alloy"
+    assert loaded["tts_format"] == "mp3"
+    assert loaded["tts_speed"] == 1.0
 
 
 def test_load_config_corrupted_json_returns_defaults(tmp_state_dir: Path) -> None:

--- a/tests/unit/test_tts_player.py
+++ b/tests/unit/test_tts_player.py
@@ -351,31 +351,6 @@ def test_start_audio_uses_native_miniaudio_fallback_for_encoded_audio(tmp_path, 
     ]
 
 
-def test_play_audio_keeps_native_handle_until_next_play(monkeypatch) -> None:
-    handles = []
-
-    class FakeHandle:
-        def __init__(self) -> None:
-            self.stopped = False
-
-        def stop(self) -> None:
-            self.stopped = True
-
-    def fake_start_audio(filepath: str):
-        handle = FakeHandle()
-        handles.append((filepath, handle))
-        return True, handle
-
-    monkeypatch.setattr(tts_player, "_LAST_PLAYBACK_HANDLE", None)
-    monkeypatch.setattr(tts_player, "_start_audio", fake_start_audio)
-
-    assert tts_player.play_audio("first.mp3") is True
-    assert tts_player.play_audio("second.mp3") is True
-
-    assert handles[0][1].stopped is True
-    assert handles[1][1].stopped is False
-
-
 def test_audio_player_command_does_not_use_external_player_for_mp3(monkeypatch) -> None:
     monkeypatch.setattr(tts_player.sys, "platform", "linux")
     monkeypatch.setattr(tts_player.shutil, "which", lambda name: f"/usr/bin/{name}")
@@ -392,15 +367,6 @@ def test_audio_player_command_does_not_xdg_open_raw_pcm(monkeypatch) -> None:
     )
 
     assert tts_player._audio_player_command("out.pcm") is None
-
-
-def test_play_audio_returns_false_when_no_player(monkeypatch) -> None:
-    monkeypatch.setattr(tts_player, "_LAST_PLAYBACK_HANDLE", None)
-    monkeypatch.setattr(tts_player, "_load_miniaudio", lambda: None)
-    monkeypatch.setattr(tts_player.sys, "platform", "linux")
-    monkeypatch.setattr(tts_player.shutil, "which", lambda name: None)
-
-    assert tts_player.play_audio("out.mp3") is False
 
 
 def test_start_audio_does_not_launch_external_app_for_tts_audio(monkeypatch) -> None:

--- a/tests/unit/test_tts_player.py
+++ b/tests/unit/test_tts_player.py
@@ -1,0 +1,449 @@
+"""Unit tests for the TTS output browser helpers."""
+
+from __future__ import annotations
+
+import subprocess
+
+from wavebench.tui import tts_player
+
+
+def test_tts_items_filters_successful_audio_outputs(tmp_path) -> None:
+    (tmp_path / "a.mp3").write_bytes(b"audio")
+    (tmp_path / "b.md").write_text("not audio")
+    (tmp_path / "missing.mp3").write_bytes(b"audio")
+    (tmp_path / "missing.mp3").unlink()
+
+    results = {
+        "ok_audio": {"status": "success", "file": "a.mp3"},
+        "ok_text": {"status": "success", "file": "b.md"},
+        "failed_audio": {"status": "failed", "file": "a.mp3"},
+        "missing_audio": {"status": "success", "file": "missing.mp3"},
+    }
+
+    assert tts_player._tts_items(str(tmp_path), results) == [
+        ("ok_audio", "a.mp3", str(tmp_path / "a.mp3"))
+    ]
+
+
+def test_browse_tts_outputs_navigates_with_arrows_and_plays_selected_file(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    (tmp_path / "first.mp3").write_bytes(b"audio-a")
+    (tmp_path / "second.mp3").write_bytes(b"audio-b")
+    results = {
+        "first": {"status": "success", "file": "first.mp3"},
+        "second": {"status": "success", "file": "second.mp3"},
+    }
+
+    class FakeTty:
+        def __init__(self) -> None:
+            self.output = ""
+
+        def isatty(self) -> bool:
+            return True
+
+        def write(self, text: str) -> None:
+            self.output += text
+
+        def flush(self) -> None:
+            pass
+
+    fake_stdout = FakeTty()
+    fake_stdin = FakeTty()
+    keys = iter(["right", "enter", "escape"])
+    started: list[str] = []
+    stopped: list[object | None] = []
+    fake_proc = object()
+
+    monkeypatch.setattr(tts_player.sys, "stdin", fake_stdin)
+    monkeypatch.setattr(tts_player.sys, "stdout", fake_stdout)
+    monkeypatch.setattr(tts_player, "_read_key_or_resize", lambda: next(keys))
+    monkeypatch.setattr(
+        tts_player, "_start_audio", lambda path: (started.append(path) or True, fake_proc)
+    )
+    monkeypatch.setattr(tts_player, "_stop_audio", lambda proc: stopped.append(proc))
+
+    tts_player.browse_tts_outputs(str(tmp_path), results)
+
+    assert started == [str(tmp_path / "second.mp3")]
+    assert stopped == [None, fake_proc]
+    assert "\033[?1049h" in fake_stdout.output  # entered alt screen
+    assert "\033[?1049l" in fake_stdout.output  # restored main screen
+
+
+def test_browse_tts_outputs_scrolls_when_outputs_exceed_screen(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    results = {}
+    for idx in range(5):
+        filename = f"voice-{idx}.mp3"
+        (tmp_path / filename).write_bytes(b"audio")
+        results[f"voice{idx}"] = {"status": "success", "file": filename}
+
+    class FakeTty:
+        def __init__(self) -> None:
+            self.output = ""
+
+        def isatty(self) -> bool:
+            return True
+
+        def write(self, text: str) -> None:
+            self.output += text
+
+        def flush(self) -> None:
+            pass
+
+    fake_stdout = FakeTty()
+    fake_stdin = FakeTty()
+    keys = iter(["down", "down", "down", "enter", "escape"])
+    started: list[str] = []
+    fake_proc = object()
+
+    monkeypatch.setattr(tts_player.sys, "stdin", fake_stdin)
+    monkeypatch.setattr(tts_player.sys, "stdout", fake_stdout)
+    monkeypatch.setattr(tts_player.shutil, "get_terminal_size", lambda fallback: tts_player.os.terminal_size((80, 8)))
+    monkeypatch.setattr(tts_player, "_read_key_or_resize", lambda: next(keys))
+    monkeypatch.setattr(
+        tts_player, "_start_audio", lambda path: (started.append(path) or True, fake_proc)
+    )
+    monkeypatch.setattr(tts_player, "_stop_audio", lambda proc: None)
+
+    tts_player.browse_tts_outputs(str(tmp_path), results)
+
+    assert started == [str(tmp_path / "voice-3.mp3")]
+    assert "showing 3-4 of 5" in fake_stdout.output
+
+
+def test_start_audio_uses_native_pulse_for_gemini_pcm(tmp_path, monkeypatch) -> None:
+    pcm = tmp_path / "gemini.pcm"
+    pcm.write_bytes(b"\x01\x02" * 8)
+    events = []
+
+    class FakePulse:
+        @staticmethod
+        def pa_simple_new(
+            _server,
+            name,
+            direction,
+            _dev,
+            stream_name,
+            sample_spec,
+            _channel_map,
+            _buffer_attr,
+            _error,
+        ):
+            spec = sample_spec._obj
+            events.append(("new", (name, direction, stream_name, spec.format, spec.rate, spec.channels)))
+            return "pulse-handle"
+
+        @staticmethod
+        def pa_simple_write(_handle, data, size, _error) -> int:
+            events.append(("write", (data[:size], size)))
+            return 0
+
+        @staticmethod
+        def pa_simple_drain(_handle, _error) -> int:
+            events.append(("drain", None))
+            return 0
+
+        @staticmethod
+        def pa_simple_free(handle) -> None:
+            events.append(("free", handle))
+
+    class FakeThread:
+        def __init__(self, target, args, daemon) -> None:
+            self.target = target
+            self.args = args
+            self.daemon = daemon
+
+        def start(self) -> None:
+            events.append(("thread", self.daemon))
+            self.target(*self.args)
+
+        def join(self, timeout: float) -> None:
+            events.append(("join", timeout))
+
+    monkeypatch.setattr(tts_player, "_load_pulse_simple", lambda: FakePulse)
+    monkeypatch.setattr(tts_player.threading, "Thread", FakeThread)
+    monkeypatch.setattr(tts_player, "_load_miniaudio", lambda: None)
+
+    launched, handle = tts_player._start_audio(str(pcm))
+
+    assert launched is True
+    assert handle is not None
+    tts_player._stop_audio(handle)
+    assert events == [
+        ("new", (b"WaveBench", 1, b"TTS output", 3, 24_000, 1)),
+        ("thread", True),
+        ("write", (b"\x01\x02" * 8, 16)),
+        ("drain", None),
+        ("free", "pulse-handle"),
+        ("join", 0.5),
+    ]
+
+
+def test_start_audio_uses_native_pulse_for_decoded_mp3(tmp_path, monkeypatch) -> None:
+    mp3 = tmp_path / "openai.mp3"
+    mp3.write_bytes(b"ID3audio")
+    events = []
+
+    class FakePulse:
+        @staticmethod
+        def pa_simple_new(
+            _server,
+            name,
+            direction,
+            _dev,
+            stream_name,
+            sample_spec,
+            _channel_map,
+            _buffer_attr,
+            _error,
+        ):
+            spec = sample_spec._obj
+            events.append(("new", (name, direction, stream_name, spec.format, spec.rate, spec.channels)))
+            return "pulse-handle"
+
+        @staticmethod
+        def pa_simple_write(_handle, data, size, _error) -> int:
+            events.append(("write", (data[:size], size)))
+            return 0
+
+        @staticmethod
+        def pa_simple_drain(_handle, _error) -> int:
+            events.append(("drain", None))
+            return 0
+
+        @staticmethod
+        def pa_simple_free(handle) -> None:
+            events.append(("free", handle))
+
+    class FakeThread:
+        def __init__(self, target, args, daemon) -> None:
+            self.target = target
+            self.args = args
+            self.daemon = daemon
+
+        def start(self) -> None:
+            events.append(("thread", self.daemon))
+            self.target(*self.args)
+
+        def join(self, timeout: float) -> None:
+            events.append(("join", timeout))
+
+    monkeypatch.setattr(tts_player, "_load_pulse_simple", lambda: FakePulse)
+    monkeypatch.setattr(tts_player.threading, "Thread", FakeThread)
+    monkeypatch.setattr(tts_player, "_decode_mpg123", lambda path: None)
+    monkeypatch.setattr(
+        tts_player,
+        "_decode_sndfile",
+        lambda path: tts_player._DecodedPcm(b"\x01\x02" * 8, 24_000, 1),
+    )
+    monkeypatch.setattr(tts_player, "_load_miniaudio", lambda: None)
+
+    launched, handle = tts_player._start_audio(str(mp3))
+
+    assert launched is True
+    assert handle is not None
+    tts_player._stop_audio(handle)
+    assert events == [
+        ("new", (b"WaveBench", 1, b"TTS output", 3, 24_000, 1)),
+        ("thread", True),
+        ("write", (b"\x01\x02" * 8, 16)),
+        ("drain", None),
+        ("free", "pulse-handle"),
+        ("join", 0.5),
+    ]
+
+
+def test_decode_encoded_audio_prefers_mpg123_for_mp3(monkeypatch) -> None:
+    calls = []
+
+    def fake_mpg123(path: str):
+        calls.append(("mpg123", path))
+        return tts_player._DecodedPcm(b"full", 22_050, 1)
+
+    def fake_sndfile(path: str):
+        calls.append(("sndfile", path))
+        return tts_player._DecodedPcm(b"short", 22_050, 1)
+
+    monkeypatch.setattr(tts_player, "_decode_mpg123", fake_mpg123)
+    monkeypatch.setattr(tts_player, "_decode_sndfile", fake_sndfile)
+
+    decoded = tts_player._decode_encoded_audio("voxtral.mp3")
+
+    assert decoded == tts_player._DecodedPcm(b"full", 22_050, 1)
+    assert calls == [("mpg123", "voxtral.mp3")]
+
+
+def test_decode_encoded_audio_falls_back_to_sndfile_without_mpg123(monkeypatch) -> None:
+    calls = []
+
+    def fake_sndfile(path: str):
+        calls.append(("sndfile", path))
+        return tts_player._DecodedPcm(b"audio", 24_000, 1)
+
+    monkeypatch.setattr(tts_player, "_decode_mpg123", lambda path: None)
+    monkeypatch.setattr(tts_player, "_decode_sndfile", fake_sndfile)
+
+    decoded = tts_player._decode_encoded_audio("openai.mp3")
+
+    assert decoded == tts_player._DecodedPcm(b"audio", 24_000, 1)
+    assert calls == [("sndfile", "openai.mp3")]
+
+
+def test_start_audio_uses_native_miniaudio_fallback_for_encoded_audio(tmp_path, monkeypatch) -> None:
+    mp3 = tmp_path / "openai.mp3"
+    mp3.write_bytes(b"ID3audio")
+    events = []
+
+    class FakeFormat:
+        SIGNED16 = "s16"
+
+    class FakeDevice:
+        def __init__(self, **kwargs) -> None:
+            events.append(("device", kwargs))
+
+        def start(self, stream) -> None:
+            events.append(("start", stream))
+
+        def close(self) -> None:
+            events.append(("close", None))
+
+    class FakeMiniaudio:
+        SampleFormat = FakeFormat
+        PlaybackDevice = FakeDevice
+
+        @staticmethod
+        def stream_file(path, **kwargs):
+            events.append(("file", (path, kwargs)))
+            return "encoded-stream"
+
+    monkeypatch.setattr(tts_player, "_start_pulse_decoded_audio", lambda path: None)
+    monkeypatch.setattr(tts_player, "_load_miniaudio", lambda: FakeMiniaudio)
+
+    launched, handle = tts_player._start_audio(str(mp3))
+
+    assert launched is True
+    assert handle is not None
+    tts_player._stop_audio(handle)
+    assert events == [
+        (
+            "file",
+            (
+                str(mp3),
+                {"output_format": "s16", "nchannels": 2, "sample_rate": 44_100},
+            ),
+        ),
+        (
+            "device",
+            {
+                "output_format": "s16",
+                "nchannels": 2,
+                "sample_rate": 44_100,
+                "app_name": "WaveBench",
+            },
+        ),
+        ("start", "encoded-stream"),
+        ("close", None),
+    ]
+
+
+def test_play_audio_keeps_native_handle_until_next_play(monkeypatch) -> None:
+    handles = []
+
+    class FakeHandle:
+        def __init__(self) -> None:
+            self.stopped = False
+
+        def stop(self) -> None:
+            self.stopped = True
+
+    def fake_start_audio(filepath: str):
+        handle = FakeHandle()
+        handles.append((filepath, handle))
+        return True, handle
+
+    monkeypatch.setattr(tts_player, "_LAST_PLAYBACK_HANDLE", None)
+    monkeypatch.setattr(tts_player, "_start_audio", fake_start_audio)
+
+    assert tts_player.play_audio("first.mp3") is True
+    assert tts_player.play_audio("second.mp3") is True
+
+    assert handles[0][1].stopped is True
+    assert handles[1][1].stopped is False
+
+
+def test_audio_player_command_does_not_use_external_player_for_mp3(monkeypatch) -> None:
+    monkeypatch.setattr(tts_player.sys, "platform", "linux")
+    monkeypatch.setattr(tts_player.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    assert tts_player._audio_player_command("out.mp3") is None
+
+
+def test_audio_player_command_does_not_xdg_open_raw_pcm(monkeypatch) -> None:
+    monkeypatch.setattr(tts_player.sys, "platform", "linux")
+    monkeypatch.setattr(
+        tts_player.shutil,
+        "which",
+        lambda name: f"/usr/bin/{name}" if name == "xdg-open" else None,
+    )
+
+    assert tts_player._audio_player_command("out.pcm") is None
+
+
+def test_play_audio_returns_false_when_no_player(monkeypatch) -> None:
+    monkeypatch.setattr(tts_player, "_LAST_PLAYBACK_HANDLE", None)
+    monkeypatch.setattr(tts_player, "_load_miniaudio", lambda: None)
+    monkeypatch.setattr(tts_player.sys, "platform", "linux")
+    monkeypatch.setattr(tts_player.shutil, "which", lambda name: None)
+
+    assert tts_player.play_audio("out.mp3") is False
+
+
+def test_start_audio_does_not_launch_external_app_for_tts_audio(monkeypatch) -> None:
+    called = []
+
+    def fake_audio_player_command(path: str):
+        called.append(path)
+        return ["/usr/bin/xdg-open", path]
+
+    def fake_popen(*args, **kwargs):
+        raise AssertionError("external player should not be launched")
+
+    monkeypatch.setattr(tts_player, "_start_native_audio", lambda path: None)
+    monkeypatch.setattr(tts_player.sys, "platform", "linux")
+    monkeypatch.setattr(tts_player, "_audio_player_command", fake_audio_player_command)
+    monkeypatch.setattr(tts_player.subprocess, "Popen", fake_popen)
+
+    launched, proc = tts_player._start_audio("out.mp3")
+
+    assert launched is False
+    assert proc is None
+    assert called == []
+
+
+def test_stop_audio_terminates_running_process() -> None:
+    class FakeProcess:
+        terminated = False
+        killed = False
+
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        def wait(self, timeout: float) -> None:
+            raise subprocess.TimeoutExpired("fake", timeout)
+
+        def kill(self) -> None:
+            self.killed = True
+
+    proc = FakeProcess()
+    tts_player._stop_audio(proc)  # type: ignore[arg-type]
+
+    assert proc.terminated is True
+    assert proc.killed is True

--- a/wavebench/__main__.py
+++ b/wavebench/__main__.py
@@ -3,7 +3,7 @@
 Parses command-line arguments, loads persistent state (models + config),
 dispatches to either ``core.main_async()`` for a benchmark run or the
 interactive config menu, and prints lifetime analytics on ``--stats``.
-Supports the interactive mode-select screen at startup (Code / Text / config).
+Supports the interactive mode-select screen at startup (Code / Text / TTS / config).
 """
 
 import argparse
@@ -21,7 +21,7 @@ except ImportError:
 import wavebench.tui.styles as _styles
 from wavebench.api import fetch_top_models, load_api_key
 from wavebench.core import main_async
-from wavebench.models import MODEL_MAPPING
+from wavebench.models import MODEL_MAPPING, TTS_MODEL_MAPPING, is_tts_model
 from wavebench.storage import (
     _history_path,
     load_config,
@@ -105,6 +105,19 @@ def main() -> None:
         action="store_true",
         help="Alias for --mode text (kept for backward compatibility).",
     )
+    parser.add_argument("--tts-voice", type=str, default=None, help="Voice for --mode tts")
+    parser.add_argument(
+        "--tts-format",
+        choices=["mp3", "pcm"],
+        default=None,
+        help="Audio format for --mode tts (default: mp3)",
+    )
+    parser.add_argument(
+        "--tts-speed",
+        type=float,
+        default=None,
+        help="Playback speed multiplier for TTS providers that support it",
+    )
     parser.add_argument("--stats", action="store_true", help="Show lifetime analytics and exit")
     parser.add_argument("--clear-history", action="store_true", help="Reset analytics history")
     parser.add_argument(
@@ -120,7 +133,7 @@ def main() -> None:
         dest="auto_open",
         choices=["incremental", "after_all"],
         default=None,
-        help="Auto-open generated files (incremental or after_all)",
+        help="Auto-open generated code/text files (incremental or after_all; TTS uses browser)",
     )
     parser.add_argument(
         "--auto-install",
@@ -202,14 +215,15 @@ def main() -> None:
 
     # ── Interactive prompt ─────────────────────────────────────────────────
     if not args.prompt:
-        text_from_cli = args.text
+        mode_from_cli = args.mode is not None or args.text
 
         def _print_mode_menu() -> None:
             active = selected_models if selected_models is not None else MODEL_MAPPING
             w = _tw() - 4
             row = (
                 f"{_styles.ACCENT_HI}[1]{S.RST} Code  "
-                f"{_styles.ACCENT}[2]{S.RST} Text"
+                f"{_styles.ACCENT}[2]{S.RST} Text  "
+                f"{_styles.ACCENT}[3]{S.RST} TTS"
                 f"  {_dot}  "
                 f"{S.DIM}{len(active)} models{S.RST}  "
                 f"{_styles.ACCENT}[c]{S.RST} config"
@@ -247,10 +261,10 @@ def main() -> None:
         _refresh_header()
 
         while True:
-            text_mode = text_from_cli
+            mode_name = args.mode or ("text" if args.text else "code")
 
-            # ── Mode selection (skip if --text was passed on CLI) ─────
-            if not text_from_cli:
+            # ── Mode selection (skip if --mode/--text was passed on CLI) ────
+            if not mode_from_cli:
                 _print_mode_menu()
                 mode_prompt = f"  {S.DIM}mode{S.RST} {_styles.ACCENT_HI}›{S.RST} "
                 sys.stdout.write(mode_prompt)
@@ -297,15 +311,33 @@ def main() -> None:
                         continue
                     if key == "2":
                         sys.stdout.write("2\n")
-                        text_mode = True
+                        mode_name = "text"
+                        mode_done = True
+                    elif key == "3":
+                        sys.stdout.write("3\n")
+                        mode_name = "tts"
                         mode_done = True
                     elif key == "1":
                         sys.stdout.write("1\n")
+                        mode_name = "code"
                         mode_done = True
                 sys.stdout.write("\033[4A\r\033[J")
                 sys.stdout.flush()
 
-            active = selected_models if selected_models is not None else MODEL_MAPPING
+            if mode_name == "tts":
+                if selected_models is None:
+                    active = TTS_MODEL_MAPPING
+                else:
+                    active = {n: m for n, m in selected_models.items() if is_tts_model(m)}
+                    if not active:
+                        active = TTS_MODEL_MAPPING
+            else:
+                if selected_models is None:
+                    active = MODEL_MAPPING
+                else:
+                    active = {n: m for n, m in selected_models.items() if not is_tts_model(m)}
+                    if not active:
+                        active = MODEL_MAPPING
             names = list(active.keys())
             summary = ", ".join(names[:6])
             if len(names) > 6:
@@ -337,7 +369,7 @@ def main() -> None:
             except _TabEscape:
                 sys.stdout.write(f"\x1b[{_PROMPT_ROW + 1};1H\x1b[J")
                 sys.stdout.flush()
-                if text_from_cli:
+                if mode_from_cli:
                     return
                 _refresh_header()
                 continue
@@ -347,7 +379,8 @@ def main() -> None:
                 print(f"  {S.DIM}Interrupted.{S.RST}\n")
                 return
             args.prompt = user_prompt.strip()
-            args.text = text_mode
+            args.mode = mode_name
+            args.text = mode_name == "text"
             break
     else:
         print()

--- a/wavebench/api.py
+++ b/wavebench/api.py
@@ -9,6 +9,7 @@ Key entry points:
   - ``load_api_key()``  — env var or ``.env`` file lookup
   - ``call_model_async()``  — non-streaming completion
   - ``call_model_streaming()``  — SSE completion with progress callback
+  - ``call_tts_speech()``  — raw audio generation via /audio/speech
   - ``fetch_top_models()``  — sync catalog fetch for the config menu
 """
 
@@ -751,6 +752,82 @@ async def call_model_streaming(
     raise RuntimeError(f"HTTP {status}: {err[:120].strip()}")
 
 
+async def call_tts_speech(
+    session: aiohttp.ClientSession,
+    api_key: str,
+    model_id: str,
+    input_text: str,
+    voice: str = "alloy",
+    response_format: str = "mp3",
+    speed: float | None = 1.0,
+    on_progress: Callable[[int], None] | None = None,
+    on_retry: RetryCallback | None = None,
+) -> tuple[bytes, dict]:
+    """Generate speech audio via OpenRouter's OpenAI-compatible TTS endpoint.
+
+    Returns ``(audio_bytes, usage)``. The endpoint returns raw audio rather
+    than JSON, so usage is a lightweight local metadata dict containing input
+    character count, output byte count, and the optional generation id header.
+    """
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "X-Title": "Benchmark Script",
+    }
+    data: dict[str, Any] = {
+        "model": model_id,
+        "input": input_text,
+        "voice": voice,
+        "response_format": response_format,
+    }
+    if speed is not None:
+        data["speed"] = speed
+
+    last_status = 0
+    last_err = ""
+    for attempt in range(1, _MAX_RETRIES + 2):
+        retry_wait_s: float | None = None
+        async with session.post(f"{API_URL}/audio/speech", headers=headers, json=data) as resp:
+            if resp.status in _RETRYABLE_STATUSES and attempt <= _MAX_RETRIES:
+                last_status = resp.status
+                last_err = await resp.text()
+                retry_wait_s = _retry_wait_seconds(resp.headers.get("Retry-After"), attempt)
+                if on_retry:
+                    on_retry(last_status, attempt, _MAX_RETRIES, retry_wait_s)
+            elif resp.status != 200:
+                text = await resp.text()
+                raise RuntimeError(f"HTTP {resp.status}: {text[:120].strip()}")
+            else:
+                chunks: list[bytes] = []
+                total_bytes = 0
+                async for chunk in resp.content.iter_chunked(64 * 1024):
+                    if not chunk:
+                        continue
+                    chunks.append(chunk)
+                    total_bytes += len(chunk)
+                    if on_progress:
+                        on_progress(total_bytes)
+
+                audio = b"".join(chunks)
+                if not audio:
+                    raise RuntimeError("empty audio response")
+
+                usage: dict[str, Any] = {
+                    "input_characters": len(input_text),
+                    "audio_bytes": total_bytes,
+                }
+                generation_id = resp.headers.get("X-Generation-Id")
+                if generation_id:
+                    usage["generation_id"] = generation_id
+                return audio, usage
+
+        if retry_wait_s is not None:
+            await asyncio.sleep(retry_wait_s)
+            continue
+
+    raise RuntimeError(f"HTTP {last_status}: {last_err[:120].strip()}")
+
+
 def fetch_top_models(api_key: str, count: int = 12) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Fetch models from OpenRouter, returning (top_for_menu, pricing_lookup).
 
@@ -760,7 +837,7 @@ def fetch_top_models(api_key: str, count: int = 12) -> tuple[list[dict[str, Any]
     the user's config).
     """
     req = urllib.request.Request(
-        f"{API_URL}/models",
+        f"{API_URL}/models?output_modalities=all",
         headers={"Authorization": f"Bearer {api_key}"},
     )
     try:
@@ -780,19 +857,23 @@ def fetch_top_models(api_key: str, count: int = 12) -> tuple[list[dict[str, Any]
         if mid:
             pricing_lookup[mid] = m.get("pricing", {})
 
-    # Filter candidates for the menu
+    # Filter candidates for the menu. Include regular text-output models plus
+    # speech-output models so TTS models can be selected from the same browser.
     seen_slugs = set()
     filtered = []
+    speech_filtered = []
     for m in all_models:
         mid = m.get("id", "")
         arch = m.get("architecture", {})
         out_mods = arch.get("output_modalities") or []
         in_mods = arch.get("input_modalities") or []
+        has_text_output = "text" in out_mods
+        has_speech_output = "speech" in out_mods
 
-        # Must accept text input and produce text output
-        if "text" not in in_mods or "text" not in out_mods:
+        # Must accept text input and produce either text or speech output.
+        if "text" not in in_mods or not (has_text_output or has_speech_output):
             continue
-        # Skip audio / image output models
+        # Skip image/audio-output models; dedicated TTS models advertise speech.
         if "audio" in out_mods or "image" in out_mods:
             continue
         # Skip :free duplicate variants (keep the paid original)
@@ -811,8 +892,16 @@ def fetch_top_models(api_key: str, count: int = 12) -> tuple[list[dict[str, Any]
             continue
         seen_slugs.add(slug)
 
-        filtered.append(m)
+        if has_speech_output:
+            speech_filtered.append(m)
+        else:
+            filtered.append(m)
 
-    # Sort by popularity score descending
+    # Sort by popularity score descending. Reserve a small slice for speech
+    # models so the config menu exposes TTS choices even when the text catalog
+    # has more than *count* high-scoring entries.
     filtered.sort(key=_model_score, reverse=True)
-    return filtered[:count], pricing_lookup
+    speech_filtered.sort(key=_model_score, reverse=True)
+    speech_count = min(len(speech_filtered), count, 20)
+    text_count = max(0, count - speech_count)
+    return filtered[:text_count] + speech_filtered[:speech_count], pricing_lookup

--- a/wavebench/core/__init__.py
+++ b/wavebench/core/__init__.py
@@ -9,8 +9,9 @@ Internal organization:
   - ``auto_open``     — terminal/viewer/tab launching
   - ``auto_install``  — dep detection + per-output-dir venv management
 
-Response modes (``CodeMode``, ``TextMode``) live in ``wavebench.modes``;
-see ``docs/CONTRIBUTING.md`` for the "Adding a new mode" walkthrough.
+Response modes (``CodeMode``, ``TextMode``, ``TTSMode``) live in
+``wavebench.modes``; see ``docs/CONTRIBUTING.md`` for the "Adding a new mode"
+walkthrough.
 """
 
 from .auto_install import (

--- a/wavebench/core/orchestrator.py
+++ b/wavebench/core/orchestrator.py
@@ -19,6 +19,7 @@ import wavebench.tui.styles as _styles
 from wavebench.api import _is_effort_naming_bridge, _map_effort, _supported_efforts
 from wavebench.modes import MODES, Mode
 from wavebench.modes.code import CodeMode
+from wavebench.modes.tts import TTSMode
 from wavebench.parsers import get_directory_name
 from wavebench.storage import load_history, record_run
 from wavebench.tui.analytics import compute_cost, display_analytics
@@ -58,21 +59,42 @@ MAX_CONCURRENCY = 12
 REQUEST_TIMEOUT = 1800  # seconds
 
 
-def _resolve_mode(args: Any, auto_install: str) -> Mode:
+def _resolve_mode(args: Any, auto_install: str, config: dict[str, Any] | None = None) -> Mode:
     """Pick the :class:`Mode` for this run based on CLI args and config.
 
     Precedence: explicit ``--mode <name>`` wins; falls back to the
     legacy ``--text`` flag (→ text mode) or defaults to code mode. When
     code mode is selected and ``auto_install == "on"``, a fresh
     ``CodeMode(allow_deps=True)`` is constructed so the system prompt
-    permits third-party packages.
+    permits third-party packages. TTS mode is constructed with configured
+    voice/format/speed.
     """
+    config = config or {}
+
+    def _configured_tts_mode() -> TTSMode:
+        voice = getattr(args, "tts_voice", None) or config.get("tts_voice", "alloy")
+        response_format = getattr(args, "tts_format", None) or config.get("tts_format", "mp3")
+        speed_raw = getattr(args, "tts_speed", None)
+        if speed_raw is None:
+            speed_raw = config.get("tts_speed", 1.0)
+        try:
+            speed = float(speed_raw)
+        except (TypeError, ValueError):
+            speed = 1.0
+        return TTSMode(
+            voice=str(voice or "alloy"),
+            response_format=str(response_format or "mp3"),
+            speed=speed,
+        )
+
     explicit = getattr(args, "mode", None)
     if explicit:
         mode = MODES.get(explicit)
         if mode is not None:
             if mode.name == "code" and auto_install == "on":
                 return CodeMode(allow_deps=True)
+            if mode.name == "tts":
+                return _configured_tts_mode()
             return mode
 
     if getattr(args, "text", False):
@@ -88,10 +110,7 @@ async def main_async(
     config: dict[str, Any] | None = None,
     pricing_lookup: dict[str, Any] | None = None,
 ) -> None:
-    from wavebench.models import MODEL_MAPPING
-
-    mapping = model_mapping if model_mapping is not None else MODEL_MAPPING
-    pad = max((len(n) for n in mapping), default=12) + 1
+    from wavebench.models import MODEL_MAPPING, TTS_MODEL_MAPPING, is_tts_model
 
     if config is None:
         from wavebench.storage import load_config
@@ -114,10 +133,34 @@ async def main_async(
     _reset_incremental_tabs()
 
     user_prompt = args.prompt
-    mode = _resolve_mode(args, auto_install)
+    mode = _resolve_mode(args, auto_install, config)
     text_mode = mode.name == "text"
+    tts_mode = mode.name == "tts"
+    if tts_mode:
+        reasoning_effort = None
+        # Avoid launching every generated audio file when a user has auto-open
+        # enabled for code/text runs; TTS has its own post-run browser/player.
+        auto_open = "off"
 
-    if text_mode:
+    if tts_mode:
+        if model_mapping is None:
+            mapping = TTS_MODEL_MAPPING
+        else:
+            mapping = {name: mid for name, mid in model_mapping.items() if is_tts_model(mid)}
+            if not mapping:
+                mapping = TTS_MODEL_MAPPING
+    else:
+        if model_mapping is None:
+            mapping = MODEL_MAPPING
+        else:
+            mapping = {name: mid for name, mid in model_mapping.items() if not is_tts_model(mid)}
+            if not mapping:
+                mapping = MODEL_MAPPING
+    pad = max((len(n) for n in mapping), default=12) + 1
+
+    if tts_mode:
+        default_ext = f".{getattr(mode, 'response_format', 'mp3')}"
+    elif text_mode:
         default_ext = ".md"
     else:
         default_ext = (
@@ -126,7 +169,7 @@ async def main_async(
 
     targets = list(mapping.items())
     if not targets:
-        print(f"  {_fail} No models configured in MODEL_MAPPING.")
+        print(f"  {_fail} No models configured.")
         return
 
     mode_label = (
@@ -152,7 +195,23 @@ async def main_async(
     )
     print(_box_divider(w, heavy=True))
     print(_box_row(f"{S.DIM}{'MODELS':>8}{S.RST}  {len(targets)} active", w, heavy=True))
-    print(_box_row(f"{S.DIM}{'REASON':>8}{S.RST}  {reasoning_label}", w, heavy=True))
+    if tts_mode:
+        print(
+            _box_row(
+                f"{S.DIM}{'VOICE':>8}{S.RST}  {S.HGRN}{getattr(mode, 'voice', 'alloy')}{S.RST}",
+                w,
+                heavy=True,
+            )
+        )
+        print(
+            _box_row(
+                f"{S.DIM}{'FORMAT':>8}{S.RST}  {getattr(mode, 'response_format', 'mp3')} (provider-adjusted)",
+                w,
+                heavy=True,
+            )
+        )
+    else:
+        print(_box_row(f"{S.DIM}{'REASON':>8}{S.RST}  {reasoning_label}", w, heavy=True))
     print(_box_row(f"{S.DIM}{'NAMING':>8}{S.RST}  {directory_naming}", w, heavy=True))
     print(_box_bot(w, heavy=True))
     print()
@@ -160,7 +219,7 @@ async def main_async(
     # Build per-model effort-adjustment notices; these get scrolled as a
     # news-ticker on the summary line once the tracker starts rendering.
     effort_ticker_msgs: list = []
-    if reasoning_effort:
+    if reasoning_effort and not tts_mode:
         for _name, model_id in targets:
             supported = _supported_efforts(model_id)
             short_id = model_id.split("/", 1)[-1]
@@ -202,6 +261,8 @@ async def main_async(
             len(targets),
             results,
             pad=pad,
+            label="Synthesizing" if tts_mode else "Generating",
+            progress_unit="bytes" if tts_mode else "tokens",
             model_names=model_names,
             avg_tokens=avg_tokens,
             pricing_lookup=pricing_lookup or {},
@@ -340,9 +401,15 @@ async def main_async(
                 sym = _ok
                 usage_d = info.get("usage", {})
                 tokens = usage_d.get("total_tokens")
+                audio_bytes = usage_d.get("audio_bytes")
                 fname = info["file"]
-                tk_part = f"  {S.DIM}{tokens:,} tk{S.RST}" if tokens else ""
-                detail = f"saved {_arrow} {S.GRN}{fname}{S.RST}{tk_part}{cost_s}"
+                if audio_bytes:
+                    usage_part = f"  {S.DIM}{ProgressTracker._format_bytes(audio_bytes)}{S.RST}"
+                elif tokens:
+                    usage_part = f"  {S.DIM}{tokens:,} tk{S.RST}"
+                else:
+                    usage_part = ""
+                detail = f"saved {_arrow} {S.GRN}{fname}{S.RST}{usage_part}{cost_s}"
             elif st == "cancelled":
                 sym = _skip
                 detail = f"{S.DIM}cancelled{S.RST}"
@@ -355,7 +422,7 @@ async def main_async(
                 overflow = _vlen(content) + 2 + len(t) - inner_w
                 max_fname = max(8, len(fname) - overflow)
                 fname = _truncate(fname, max_fname)
-                detail = f"saved {_arrow} {S.GRN}{fname}{S.RST}{tk_part}{cost_s}"
+                detail = f"saved {_arrow} {S.GRN}{fname}{S.RST}{usage_part}{cost_s}"
                 content = f"{rank} {sym} {_rpad(name, pad)}  {detail}"
             gap = max(inner_w - _vlen(content) - len(t), 2)
             print(_box_row(f"{content}{' ' * gap}{S.DIM}{t}{S.RST}", w))
@@ -384,7 +451,11 @@ async def main_async(
         total_time,
         results,
         costs=run_costs,
-        reasoning_effort=raw_effort,
+        reasoning_effort=raw_effort if not tts_mode else None,
     )
     display_analytics(history, compact=True, pad=pad, sort_by=config.get("analytics_sort", "runs"))
+    if tts_mode and output_dir_final[0]:
+        from wavebench.tui.tts_player import browse_tts_outputs
+
+        browse_tts_outputs(output_dir_final[0], results)
     print()

--- a/wavebench/core/runner.py
+++ b/wavebench/core/runner.py
@@ -1,8 +1,9 @@
 """Per-model benchmark runner and the filename utility it shares.
 
 ``run_model`` is the single mode-parameterized driver that streams an
-LLM response, parses it via the supplied :class:`~wavebench.modes.Mode`,
-writes the output file, and (for code mode) optionally detects Python
+LLM response (or TTS audio bytes), parses it via the supplied
+:class:`~wavebench.modes.Mode`, writes the output file, and (for code mode)
+optionally detects Python
 dependencies and installs them into a shared per-output-dir venv.
 
 Previously this module held a ``process_model`` / ``process_model_text``
@@ -24,8 +25,9 @@ from typing import Any
 
 import aiohttp
 
-from wavebench.api import call_model_streaming
-from wavebench.modes import Mode
+from wavebench.api import call_model_streaming, call_tts_speech
+from wavebench.models import tts_response_format_for_model, tts_voice_for_model
+from wavebench.modes import Mode, ParsedOutput
 from wavebench.tui.styles import (
     S,
     _arrow,
@@ -86,12 +88,12 @@ async def run_model(
 
     ``mode.frame_prompt`` wraps *user_prompt* with mode-specific
     instructions; ``mode.parse_response`` converts the raw streamed
-    response into a :class:`~wavebench.modes.ParsedOutput` whose
+    response/audio into a :class:`~wavebench.modes.ParsedOutput` whose
     ``extension`` drives the saved file's suffix.
 
     When ``mode.name == "code"`` AND ``auto_install == "on"`` AND the
     parsed extension is ``py``, dependency detection + venv setup fire
-    as before. Text mode skips that branch entirely.
+    as before. Text and TTS modes skip that branch entirely.
     """
     start = time.monotonic()
     registered = tracker.is_running
@@ -102,9 +104,10 @@ async def run_model(
         print(f"  {_wait} {model_name:<{pad}}  {S.DIM}calling {model_id}…{S.RST}")
 
     framed_prompt = mode.frame_prompt(user_prompt)
-    content: str | None = None
+    content: str | bytes | None = None
     usage: dict = {}
     retry_events: list[dict[str, Any]] = []
+    effective_tts_format = getattr(mode, "response_format", "mp3")
 
     try:
         async with semaphore:
@@ -126,15 +129,32 @@ async def run_model(
                         f"{S.DIM}retry {attempt}/{max_attempts} in {wait_s:.1f}s{S.RST}"
                     )
 
-            content, usage = await call_model_streaming(
-                session,
-                api_key,
-                model_id,
-                framed_prompt,
-                reasoning_effort=reasoning_effort,
-                on_progress=_on_progress,
-                on_retry=_on_retry,
-            )
+            if mode.name == "tts":
+                effective_tts_format = tts_response_format_for_model(
+                    model_id,
+                    getattr(mode, "response_format", "mp3"),
+                )
+                content, usage = await call_tts_speech(
+                    session,
+                    api_key,
+                    model_id,
+                    framed_prompt,
+                    voice=tts_voice_for_model(model_id, getattr(mode, "voice", "alloy")),
+                    response_format=effective_tts_format,
+                    speed=getattr(mode, "speed", 1.0),
+                    on_progress=_on_progress,
+                    on_retry=_on_retry,
+                )
+            else:
+                content, usage = await call_model_streaming(
+                    session,
+                    api_key,
+                    model_id,
+                    framed_prompt,
+                    reasoning_effort=reasoning_effort,
+                    on_progress=_on_progress,
+                    on_retry=_on_retry,
+                )
 
     except asyncio.CancelledError:
         elapsed = time.monotonic() - start
@@ -230,6 +250,12 @@ async def run_model(
 
     try:
         parsed = mode.parse_response(content)
+        if mode.name == "tts" and parsed.parse_ok:
+            parsed = ParsedOutput(
+                content=parsed.content,
+                extension=effective_tts_format,
+                parse_ok=True,
+            )
 
         if not parsed.parse_ok:
             elapsed = time.monotonic() - start
@@ -253,8 +279,12 @@ async def run_model(
         filename = get_unique_filename(output_dir, model_name, ext)
         filepath = os.path.join(output_dir, filename)
 
-        with open(filepath, "w", encoding="utf-8") as fh:
-            fh.write(parsed.content)
+        if isinstance(parsed.content, bytes):
+            with open(filepath, "wb") as fh:
+                fh.write(parsed.content)
+        else:
+            with open(filepath, "w", encoding="utf-8") as fh:
+                fh.write(parsed.content)
 
         # Code-mode dependency auto-install lives here rather than inside
         # the Mode itself so orchestrator-level config (auto_install,

--- a/wavebench/models.py
+++ b/wavebench/models.py
@@ -1,10 +1,10 @@
 """Default model mapping and ranking algorithm.
 
-Holds the fallback ``MODEL_MAPPING`` used when no persistent selection
-exists, and ``_model_score()`` — the heuristic that ranks the OpenRouter
-catalog by provider tier, pricing, recency, reasoning/tool capability,
-and context length. Also exposes ``is_stealth()`` for classifying cloaked
-``openrouter/*`` models.
+Holds the fallback ``MODEL_MAPPING`` and ``TTS_MODEL_MAPPING`` used when no
+persistent selection exists, and ``_model_score()`` — the heuristic that ranks
+the OpenRouter catalog by provider tier, pricing, recency, reasoning/tool
+capability, and context length. Also exposes ``is_stealth()`` and
+``is_tts_model()`` classifiers plus TTS provider defaults.
 """
 
 import time
@@ -15,6 +15,17 @@ MODEL_MAPPING: dict[str, str] = {
     "minimax_m2.5": "minimax/minimax-m2.5",
     "glm5": "z-ai/glm-5",
     "claudeOpus4.6": "anthropic/claude-opus-4.6",
+}
+
+TTS_MODEL_MAPPING: dict[str, str] = {
+    "gpt4oMiniTTS": "openai/gpt-4o-mini-tts-2025-12-15",
+    "gemini3.1FlashTTS": "google/gemini-3.1-flash-tts-preview",
+    "voxtralMiniTts2603": "mistralai/voxtral-mini-tts-2603",
+    "csm1b": "sesame/csm-1b",
+    "zonosV0.1Hybrid": "zyphra/zonos-v0.1-hybrid",
+    "zonosV0.1Transformer": "zyphra/zonos-v0.1-transformer",
+    "orpheus3b": "canopylabs/orpheus-3b-0.1-ft",
+    "kokoro82m": "hexgrad/kokoro-82m",
 }
 
 _TIER1_PROVIDERS: frozenset[str] = frozenset(
@@ -39,6 +50,67 @@ _TIER2_PROVIDERS: frozenset[str] = frozenset(
         "qwen",
     }
 )
+
+_KNOWN_TTS_MODEL_IDS: frozenset[str] = frozenset(
+    {
+        "google/gemini-3.1-flash-tts-preview",
+        "zyphra/zonos-v0.1-transformer",
+        "zyphra/zonos-v0.1-hybrid",
+        "sesame/csm-1b",
+        "canopylabs/orpheus-3b-0.1-ft",
+        "hexgrad/kokoro-82m",
+        "mistralai/voxtral-mini-tts-2603",
+        "openai/gpt-4o-mini-tts-2025-12-15",
+    }
+)
+_TTS_ID_MARKERS: frozenset[str] = frozenset(
+    {"tts", "speech", "voxtral", "zonos", "csm-1b", "orpheus", "kokoro"}
+)
+_DEFAULT_TTS_VOICE_BY_MARKER: tuple[tuple[str, str], ...] = (
+    ("google/", "Kore"),
+    ("mistralai/voxtral", "en_paul_neutral"),
+    ("zyphra/zonos", "american_female"),
+    ("sesame/csm", "conversational_a"),
+    ("canopylabs/orpheus", "tara"),
+    ("hexgrad/kokoro", "af_alloy"),
+)
+_DEFAULT_TTS_FORMAT_BY_MARKER: tuple[tuple[str, str], ...] = (
+    ("google/", "pcm"),
+    ("mistralai/voxtral", "mp3"),
+    ("zyphra/zonos", "mp3"),
+)
+
+
+def is_tts_model(model_id: str) -> bool:
+    """Heuristic for user-configured models that target speech synthesis."""
+    lower = model_id.lower()
+    return lower in _KNOWN_TTS_MODEL_IDS or any(marker in lower for marker in _TTS_ID_MARKERS)
+
+
+def tts_voice_for_model(model_id: str, configured_voice: str) -> str:
+    """Return a provider-compatible voice for bundled TTS defaults.
+
+    The app's default voice is OpenAI's ``alloy``. When benchmarking known
+    non-OpenAI TTS models, map that default to a provider-supported voice.
+    Explicit user voices pass through unchanged.
+    """
+    if configured_voice != "alloy":
+        return configured_voice
+    lower = model_id.lower()
+    for marker, voice in _DEFAULT_TTS_VOICE_BY_MARKER:
+        if marker in lower:
+            return voice
+    return configured_voice
+
+
+def tts_response_format_for_model(model_id: str, configured_format: str) -> str:
+    """Return a response format accepted by known OpenRouter TTS providers."""
+    lower = model_id.lower()
+    for marker, response_format in _DEFAULT_TTS_FORMAT_BY_MARKER:
+        if marker in lower:
+            return response_format
+    return configured_format
+
 
 _OPENROUTER_UTILITY: frozenset[str] = frozenset(
     {

--- a/wavebench/models.py
+++ b/wavebench/models.py
@@ -104,7 +104,14 @@ def tts_voice_for_model(model_id: str, configured_voice: str) -> str:
 
 
 def tts_response_format_for_model(model_id: str, configured_format: str) -> str:
-    """Return a response format accepted by known OpenRouter TTS providers."""
+    """Return a response format accepted by known OpenRouter TTS providers.
+
+    The app's default TTS format is OpenAI's ``mp3``. When benchmarking known
+    non-OpenAI TTS models, map that default to a provider-supported format.
+    Explicit user formats pass through unchanged.
+    """
+    if configured_format != "mp3":
+        return configured_format
     lower = model_id.lower()
     for marker, response_format in _DEFAULT_TTS_FORMAT_BY_MARKER:
         if marker in lower:

--- a/wavebench/modes/__init__.py
+++ b/wavebench/modes/__init__.py
@@ -1,4 +1,4 @@
-"""Response modes — first-class abstractions over Code / Text / future variants.
+"""Response modes — first-class abstractions over Code / Text / TTS variants.
 
 A ``Mode`` captures two mode-specific decisions that used to be spread
 across ``process_model``/``process_model_text``:
@@ -8,9 +8,10 @@ across ``process_model``/``process_model_text``:
   - **Response parsing** — how to convert a raw LLM response into a
     :class:`ParsedOutput` (content, extension, pass/fail).
 
-Concrete modes live in ``code.py`` (``CodeMode``) and ``text.py``
-(``TextMode``). The ``MODES`` registry is populated on import and keyed
-by each mode's ``name`` for CLI lookup (``--mode code``, ``--mode text``).
+Concrete modes live in ``code.py`` (``CodeMode``), ``text.py``
+(``TextMode``), and ``tts.py`` (``TTSMode``). The ``MODES`` registry is
+populated on import and keyed by each mode's ``name`` for CLI lookup
+(``--mode code``, ``--mode text``, ``--mode tts``).
 
 ## Adding a new mode
 
@@ -35,8 +36,8 @@ class ParsedOutput:
     """Result of converting a raw LLM response into a savable file payload.
 
     Attributes:
-        content: Bytes to write to the output file (including any trailing
-            newline the mode wants to enforce).
+        content: Text or bytes to write to the output file (including any
+            trailing newline the mode wants to enforce).
         extension: File extension without the leading dot — e.g., ``"py"``,
             ``"md"``, ``"html"``. Empty string means "unknown".
         parse_ok: True if the mode was able to recognize meaningful output,
@@ -46,7 +47,7 @@ class ParsedOutput:
             ``None`` otherwise.
     """
 
-    content: str
+    content: str | bytes
     extension: str
     parse_ok: bool
     parse_error: str | None = None
@@ -68,14 +69,15 @@ class Mode(Protocol):
         """Wrap the raw user prompt with mode-specific instructions.
 
         Returns a single string that the OpenRouter client will send as
-        the ``user`` message content. (The spec envisioned an OpenAI-style
-        messages list; the current client accepts only a string prompt,
-        so we match that — upgrading is a separate concern.)
+        the ``user`` message content for chat modes or as ``input`` for
+        TTS mode. (The spec envisioned an OpenAI-style messages list; the
+        current chat client accepts only a string prompt, so we match that
+        — upgrading is a separate concern.)
         """
         ...
 
-    def parse_response(self, raw: str) -> ParsedOutput:
-        """Turn a raw streamed LLM response into a :class:`ParsedOutput`."""
+    def parse_response(self, raw: str | bytes) -> ParsedOutput:
+        """Turn a raw model response into a :class:`ParsedOutput`."""
         ...
 
 
@@ -90,14 +92,17 @@ def register(mode: Mode) -> None:
 # ── Built-in modes ───────────────────────────────────────────────────────
 from .code import CODE_MODE  # noqa: E402  (avoid circular import)
 from .text import TEXT_MODE  # noqa: E402
+from .tts import TTS_MODE  # noqa: E402
 
 register(CODE_MODE)
 register(TEXT_MODE)
+register(TTS_MODE)
 
 __all__ = [
     "CODE_MODE",
     "MODES",
     "TEXT_MODE",
+    "TTS_MODE",
     "Mode",
     "ParsedOutput",
     "register",

--- a/wavebench/modes/code.py
+++ b/wavebench/modes/code.py
@@ -50,7 +50,9 @@ class CodeMode:
         sys_prompt = _SYSTEM_PROMPT_CODE_DEPS if self.allow_deps else _SYSTEM_PROMPT_CODE
         return f"{sys_prompt}\n\nTask: {user_prompt}"
 
-    def parse_response(self, raw: str) -> ParsedOutput:
+    def parse_response(self, raw: str | bytes) -> ParsedOutput:
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8", errors="replace")
         parsed = extract_code(raw)
         if not parsed or not parsed.get("code"):
             return ParsedOutput(

--- a/wavebench/modes/text.py
+++ b/wavebench/modes/text.py
@@ -28,7 +28,9 @@ class TextMode:
     def frame_prompt(self, user_prompt: str) -> str:
         return f"{_SYSTEM_PROMPT_TEXT}\n\nQuestion: {user_prompt}"
 
-    def parse_response(self, raw: str) -> ParsedOutput:
+    def parse_response(self, raw: str | bytes) -> ParsedOutput:
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8", errors="replace")
         if not raw or not raw.strip():
             return ParsedOutput(
                 content="",

--- a/wavebench/modes/tts.py
+++ b/wavebench/modes/tts.py
@@ -1,0 +1,43 @@
+"""TTS mode — synthesizes speech audio from the user's text.
+
+Unlike Code/Text mode, TTS mode does not ask a chat model to transform the
+prompt. The framed prompt is the exact text to synthesize, and parsing simply
+validates the raw audio bytes returned by OpenRouter's `/audio/speech` endpoint.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from wavebench.modes import ParsedOutput
+
+
+@dataclass(frozen=True)
+class TTSMode:
+    """Text-to-speech mode using OpenRouter's audio speech endpoint."""
+
+    name: str = "tts"
+    display_name: str = "TTS"
+    voice: str = "alloy"
+    response_format: str = "mp3"
+    speed: float = 1.0
+
+    def frame_prompt(self, user_prompt: str) -> str:
+        return user_prompt.strip()
+
+    def parse_response(self, raw: str | bytes) -> ParsedOutput:
+        if not isinstance(raw, bytes) or not raw:
+            return ParsedOutput(
+                content=b"",
+                extension=self.response_format,
+                parse_ok=False,
+                parse_error="empty audio response",
+            )
+        return ParsedOutput(
+            content=raw,
+            extension=self.response_format,
+            parse_ok=True,
+        )
+
+
+TTS_MODE = TTSMode()

--- a/wavebench/storage.py
+++ b/wavebench/storage.py
@@ -71,6 +71,9 @@ def load_config() -> dict[str, Any]:
         "auto_open": "off",
         "auto_install": "off",
         "directory_naming": "llm",
+        "tts_voice": "alloy",
+        "tts_format": "mp3",
+        "tts_speed": 1.0,
     }
     if os.path.exists(path):
         try:

--- a/wavebench/tui/analytics/cost.py
+++ b/wavebench/tui/analytics/cost.py
@@ -20,9 +20,14 @@ def compute_cost(usage: dict[str, Any], pricing: dict[str, Any]) -> float | None
     try:
         pp = float(pricing.get("prompt") or 0)
         cp = float(pricing.get("completion") or 0)
+        request_cost = float(pricing.get("request") or 0)
     except (TypeError, ValueError):
         return None
+    input_chars = usage.get("input_characters")
+    if input_chars is not None:
+        cost = input_chars * pp + request_cost
+        return cost if cost > 0 else None
     prompt_tokens = usage.get("prompt_tokens") or 0
     completion_tokens = usage.get("completion_tokens") or 0
-    cost = prompt_tokens * pp + completion_tokens * cp
+    cost = prompt_tokens * pp + completion_tokens * cp + request_cost
     return cost if cost > 0 else None

--- a/wavebench/tui/menus/config_menu.py
+++ b/wavebench/tui/menus/config_menu.py
@@ -1,12 +1,11 @@
-"""Tabbed configuration menu — Models tab (catalog browser + manual add)
+"""Tabbed configuration menu — Models/TTS tabs (catalog browser + manual add)
 and Settings tab (theme, reasoning-effort, analytics sort, directory naming,
 auto-open, auto-install).
 
-``interactive_config_menu`` is a single ~500-line function that drives
-both tabs through a shared event loop; further decomposition is deferred
-per the maintainability spec. ``run_config_menu`` is the thin wrapper
-that fetches the OpenRouter catalog (or accepts a prefetched pair) before
-entering the menu.
+``interactive_config_menu`` is a single function that drives the tabs through
+a shared event loop; further decomposition is deferred per the maintainability
+spec. ``run_config_menu`` is the thin wrapper that fetches the OpenRouter
+catalog (or accepts a prefetched pair) before entering the menu.
 
 Theme changes are applied live during cycling and reverted on cancel so
 the user sees each theme before committing.
@@ -21,13 +20,12 @@ import sys
 from typing import Any
 
 from wavebench.api import fetch_top_models
-from wavebench.models import MODEL_MAPPING
+from wavebench.models import MODEL_MAPPING, TTS_MODEL_MAPPING, is_tts_model
 from wavebench.parsers import _DIRECTORY_NAMING_CHOICES
 from wavebench.tui import styles as _styles
 from wavebench.tui.input import _read_key_or_resize
 from wavebench.tui.menus._shared import (
     MODEL_MENU_LIMIT,
-    _filter_model_indices,
     _fit,
     _format_price,
     _is_printable_search_char,
@@ -53,13 +51,88 @@ except ImportError:
 _HAS_SIGWINCH = hasattr(signal, "SIGWINCH")
 
 
+def _build_config_model_items(
+    available_models: list[dict[str, Any]],
+    current_mapping: dict[str, str],
+    pricing_lookup: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Build config-menu model rows with text and TTS defaults separated."""
+    pricing_lookup = pricing_lookup or {}
+    items: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    existing_names: set[str] = set()
+    category_counts = {False: 0, True: 0}
+
+    selected_pairs = list(current_mapping.items())
+    selected_ids = {model_id for _, model_id in selected_pairs}
+    if not any(not is_tts_model(model_id) for _, model_id in selected_pairs):
+        for short_name, model_id in MODEL_MAPPING.items():
+            if model_id not in selected_ids:
+                selected_pairs.append((short_name, model_id))
+                selected_ids.add(model_id)
+    if not any(is_tts_model(model_id) for _, model_id in selected_pairs):
+        for short_name, model_id in TTS_MODEL_MAPPING.items():
+            if model_id not in selected_ids:
+                selected_pairs.append((short_name, model_id))
+                selected_ids.add(model_id)
+
+    def add_item(short_name: str, model_id: str, *, selected: bool) -> int | None:
+        if not model_id or model_id in seen_ids:
+            return None
+        if selected and short_name and short_name not in existing_names:
+            short = short_name
+        else:
+            short = _unique_short_name(model_id, existing_names)
+        seen_ids.add(model_id)
+        existing_names.add(short)
+        is_tts = is_tts_model(model_id)
+        category_counts[is_tts] += 1
+        items.append(
+            {
+                "short": short,
+                "id": model_id,
+                "selected": selected,
+                "pricing": _format_price(pricing_lookup.get(model_id, {})),
+                "is_tts": is_tts,
+            }
+        )
+        return len(items) - 1
+
+    for short_name, model_id in selected_pairs:
+        add_item(short_name, model_id, selected=True)
+
+    for m in available_models:
+        mid = m.get("id", "")
+        is_tts = is_tts_model(mid)
+        if category_counts[is_tts] >= MODEL_MENU_LIMIT or mid in seen_ids:
+            continue
+        add_item("", mid, selected=False)
+
+    return items
+
+
+def _filter_config_model_indices(
+    items: list[dict[str, Any]], query: str, *, tts: bool
+) -> list[int]:
+    """Return model row indices for one config-menu model tab."""
+    tab_indices = [i for i, item in enumerate(items) if bool(item.get("is_tts")) is tts]
+    needle = query.strip().lower()
+    if not needle:
+        return tab_indices
+    return [
+        i
+        for i in tab_indices
+        if needle in items[i]["short"].lower() or needle in items[i]["id"].lower()
+    ]
+
+
 def interactive_config_menu(
     available_models: list[dict[str, Any]],
     current_mapping: dict[str, str],
     current_config: dict[str, Any],
     pricing_lookup: dict[str, Any] | None = None,
 ) -> tuple[dict[str, str] | None, dict[str, Any] | None]:
-    """Tabbed configuration menu with Models and Settings pages."""
+    """Tabbed configuration menu with separate Models, TTS, and Settings pages."""
     if not sys.stdin.isatty() or not _HAS_TTY:
         print(f"  {S.DIM}Interactive menu requires a terminal.{S.RST}")
         return None, None
@@ -67,48 +140,43 @@ def interactive_config_menu(
     _original_theme = current_config.get("theme", "default")
 
     pricing_lookup = pricing_lookup or {}
-    tabs = ["Models", "Settings"]
-    active_tab = 0
+    MODEL_TAB = 0
+    TTS_TAB = 1
+    SETTINGS_TAB = 2
+    MODEL_TABS = (MODEL_TAB, TTS_TAB)
+    tabs = ["Models", "TTS", "Settings"]
+    active_tab = MODEL_TAB
 
-    model_items = []
-    seen_ids = set()
-    existing_names = set()
-
-    for short_name, model_id in current_mapping.items():
-        model_items.append(
-            {
-                "short": short_name,
-                "id": model_id,
-                "selected": True,
-                "pricing": _format_price(pricing_lookup.get(model_id, {})),
-            }
-        )
-        seen_ids.add(model_id)
-        existing_names.add(short_name)
-
-    for m in available_models:
-        if len(model_items) >= MODEL_MENU_LIMIT:
-            break
-        mid = m.get("id", "")
-        if mid in seen_ids:
-            continue
-        seen_ids.add(mid)
-        short = _unique_short_name(mid, existing_names)
-        existing_names.add(short)
-        model_items.append(
-            {
-                "short": short,
-                "id": mid,
-                "selected": False,
-                "pricing": _format_price(pricing_lookup.get(mid, {})),
-            }
-        )
+    model_items = _build_config_model_items(available_models, current_mapping, pricing_lookup)
+    seen_ids = {item["id"] for item in model_items}
+    existing_names = {item["short"] for item in model_items}
 
     from wavebench.tui.styles import THEME_NAMES
 
     REASONING_CHOICES = ["max", "xhigh", "high", "medium", "low", "off"]
     SORT_CHOICES = ["runs", "avg_time", "rate", "avg_tokens", "cost"]
     AUTO_OPEN_CHOICES = ["off", "incremental", "after_all"]
+    TTS_VOICE_CHOICES = [
+        "alloy",
+        "ash",
+        "ballad",
+        "coral",
+        "echo",
+        "fable",
+        "nova",
+        "onyx",
+        "sage",
+        "shimmer",
+        "verse",
+        "Kore",
+        "Puck",
+        "en_paul_neutral",
+        "american_female",
+        "conversational_a",
+        "tara",
+        "af_alloy",
+    ]
+    TTS_SPEED_CHOICES = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0]
 
     settings_items = [
         {
@@ -147,6 +215,27 @@ def interactive_config_menu(
             "choices": AUTO_OPEN_CHOICES,
         },
         {
+            "key": "tts_voice",
+            "label": "TTS voice",
+            "value": current_config.get("tts_voice", "alloy"),
+            "type": "cycle",
+            "choices": TTS_VOICE_CHOICES,
+        },
+        {
+            "key": "tts_format",
+            "label": "TTS format",
+            "value": current_config.get("tts_format", "mp3"),
+            "type": "cycle",
+            "choices": ["mp3", "pcm"],
+        },
+        {
+            "key": "tts_speed",
+            "label": "TTS speed",
+            "value": current_config.get("tts_speed", 1.0),
+            "type": "cycle",
+            "choices": TTS_SPEED_CHOICES,
+        },
+        {
             "key": "auto_install",
             "label": "Auto-install deps",
             "value": current_config.get("auto_install", "off"),
@@ -170,14 +259,28 @@ def interactive_config_menu(
             visible.append((i, item))
         return visible
 
-    model_cursor = 0
+    model_cursor = {
+        tab: next(
+            (
+                i
+                for i, item in enumerate(model_items)
+                if bool(item.get("is_tts")) is (tab == TTS_TAB)
+            ),
+            0,
+        )
+        for tab in MODEL_TABS
+    }
     _CHROME_LINES = 8
     model_page_size = max(1, min(14, shutil.get_terminal_size((80, 24)).lines - _CHROME_LINES))
-    model_page = 0
-    model_search_query = ""
-    filtered_model_indices = list(range(len(model_items)))
+    model_page = {MODEL_TAB: 0, TTS_TAB: 0}
+    model_search_query = {MODEL_TAB: "", TTS_TAB: ""}
+    filtered_model_indices = {
+        MODEL_TAB: _filter_config_model_indices(model_items, "", tts=False),
+        TTS_TAB: _filter_config_model_indices(model_items, "", tts=True),
+    }
     settings_cursor = 0
     adding_model = False
+    adding_model_tab = MODEL_TAB
     add_model_buffer = ""
 
     if not model_items:
@@ -194,35 +297,49 @@ def interactive_config_menu(
 
     content_height = max(model_page_size, len(settings_items))
 
-    def _model_page_count() -> int:
-        return max(1, (len(filtered_model_indices) + model_page_size - 1) // model_page_size)
+    def _is_model_tab(tab: int | None = None) -> bool:
+        return (active_tab if tab is None else tab) in MODEL_TABS
 
-    def _sync_model_page_from_cursor() -> None:
-        nonlocal model_cursor, model_page
-        if not filtered_model_indices:
-            model_page = 0
+    def _model_tab_is_tts(tab: int) -> bool:
+        return tab == TTS_TAB
+
+    def _model_page_count(tab: int | None = None) -> int:
+        tab = active_tab if tab is None else tab
+        indices = filtered_model_indices[tab]
+        return max(1, (len(indices) + model_page_size - 1) // model_page_size)
+
+    def _sync_model_page_from_cursor(tab: int | None = None) -> None:
+        tab = active_tab if tab is None else tab
+        indices = filtered_model_indices[tab]
+        if not indices:
+            model_page[tab] = 0
             return
-        if model_cursor not in filtered_model_indices:
-            model_cursor = filtered_model_indices[0]
-        model_page = filtered_model_indices.index(model_cursor) // model_page_size
+        if model_cursor[tab] not in indices:
+            model_cursor[tab] = indices[0]
+        model_page[tab] = indices.index(model_cursor[tab]) // model_page_size
 
-    def _model_page_bounds() -> tuple[int, int]:
-        start = model_page * model_page_size
-        end = min(start + model_page_size, len(filtered_model_indices))
+    def _model_page_bounds(tab: int | None = None) -> tuple[int, int]:
+        tab = active_tab if tab is None else tab
+        indices = filtered_model_indices[tab]
+        start = model_page[tab] * model_page_size
+        end = min(start + model_page_size, len(indices))
         return start, end
 
-    def _refresh_model_filter(preserve_current: bool = True) -> None:
-        nonlocal model_cursor, model_page, filtered_model_indices
-        current = model_cursor
-        filtered_model_indices = _filter_model_indices(model_items, model_search_query)
-        if not filtered_model_indices:
-            model_page = 0
+    def _refresh_model_filter(tab: int | None = None, preserve_current: bool = True) -> None:
+        tab = active_tab if tab is None else tab
+        current = model_cursor[tab]
+        filtered_model_indices[tab] = _filter_config_model_indices(
+            model_items, model_search_query[tab], tts=_model_tab_is_tts(tab)
+        )
+        indices = filtered_model_indices[tab]
+        if not indices:
+            model_page[tab] = 0
             return
-        if preserve_current and current in filtered_model_indices:
-            model_cursor = current
+        if preserve_current and current in indices:
+            model_cursor[tab] = current
         else:
-            model_cursor = filtered_model_indices[0]
-        _sync_model_page_from_cursor()
+            model_cursor[tab] = indices[0]
+        _sync_model_page_from_cursor(tab)
 
     def render() -> None:
         nonlocal model_page_size, content_height, short_w, id_w, model_page
@@ -231,8 +348,10 @@ def interactive_config_menu(
         if new_ps != model_page_size:
             model_page_size = new_ps
             content_height = max(model_page_size, len(settings_items))
-            if filtered_model_indices and model_cursor in filtered_model_indices:
-                model_page = filtered_model_indices.index(model_cursor) // model_page_size
+            for tab in MODEL_TABS:
+                indices = filtered_model_indices[tab]
+                if indices and model_cursor[tab] in indices:
+                    model_page[tab] = indices.index(model_cursor[tab]) // model_page_size
         w = max(20, min(120, term.columns) - 4)
         _avail = max(10, (w - 4) - _overhead)
         short_w, id_w = _nat_short_w, _nat_id_w
@@ -255,27 +374,28 @@ def interactive_config_menu(
                 tab_parts.append(f"{S.DIM} {name} {S.RST}")
         buf.append(_box_row("   ".join(tab_parts), w) + "\033[K\n")
 
-        if active_tab == 0:
+        if _is_model_tab():
             if adding_model:
-                add_label = f"{S.HGRN}add model{S.RST}"
+                label = "add TTS model" if adding_model_tab == TTS_TAB else "add model"
+                add_label = f"{S.HGRN}{label}{S.RST}"
                 add_query = add_model_buffer or f"{S.DIM}provider/model-id{S.RST}"
                 buf.append(_box_row(f"{add_label}: {add_query}", w) + "\033[K\n")
             else:
-                search_label = (
-                    f"{_styles.ACCENT_HI}search{S.RST}" if model_search_query else "search"
-                )
-                query = model_search_query or f"{S.DIM}type to filter{S.RST}"
-                buf.append(_box_row(f"{search_label}: {query}", w) + "\033[K\n")
+                query = model_search_query[active_tab]
+                search_label = f"{_styles.ACCENT_HI}search{S.RST}" if query else "search"
+                query_display = query or f"{S.DIM}type to filter{S.RST}"
+                buf.append(_box_row(f"{search_label}: {query_display}", w) + "\033[K\n")
         else:
             buf.append(_box_row("", w) + "\033[K\n")
 
         for row in range(content_height):
-            if active_tab == 0:
+            if _is_model_tab():
+                indices = filtered_model_indices[active_tab]
                 start, end = _model_page_bounds()
                 if row < (end - start):
-                    item_idx = filtered_model_indices[start + row]
+                    item_idx = indices[start + row]
                     item = model_items[item_idx]
-                    is_cur = item_idx == model_cursor
+                    is_cur = item_idx == model_cursor[active_tab]
                     chk = f"{S.HGRN}✓{S.RST}" if item["selected"] else " "
                     sn = _fit(item["short"], short_w)
                     mi = _fit(item["id"], id_w)
@@ -289,11 +409,11 @@ def interactive_config_menu(
                         ids = f"{S.DIM}{mi:<{id_w}}{S.RST}"
                     ps = f"  {S.DIM}{item['pricing']}{S.RST}" if item["pricing"] else ""
                     buf.append(_box_row(f"{mk} [{chk}] {ns} {ids}{ps}", w) + "\033[K\n")
-                elif row == 0 and not filtered_model_indices:
-                    buf.append(
-                        _box_row(f"{S.DIM}No models match the current search.{S.RST}", w)
-                        + "\033[K\n"
-                    )
+                elif row == 0 and not indices:
+                    message = "No TTS models match the current search."
+                    if active_tab == MODEL_TAB:
+                        message = "No models match the current search."
+                    buf.append(_box_row(f"{S.DIM}{message}{S.RST}", w) + "\033[K\n")
                 else:
                     buf.append(_box_row("", w) + "\033[K\n")
             else:
@@ -353,14 +473,20 @@ def interactive_config_menu(
 
         buf.append(_box_row("", w) + "\033[K\n")
 
-        if active_tab == 0:
-            sel = sum(1 for it in model_items if it["selected"])
+        if _is_model_tab():
+            is_tts_tab = active_tab == TTS_TAB
+            tab_total = sum(1 for it in model_items if bool(it.get("is_tts")) is is_tts_tab)
+            sel = sum(
+                1
+                for it in model_items
+                if it["selected"] and bool(it.get("is_tts")) is is_tts_tab
+            )
             pcount = _model_page_count()
             status = (
                 f"{S.BOLD}{sel}{S.RST} of "
-                f"{len(model_items)} selected  "
-                f"{S.DIM}{len(filtered_model_indices)} shown{S.RST}  "
-                f"{S.DIM}page {model_page + 1}/{pcount}{S.RST}"
+                f"{tab_total} selected  "
+                f"{S.DIM}{len(filtered_model_indices[active_tab])} shown{S.RST}  "
+                f"{S.DIM}page {model_page[active_tab] + 1}/{pcount}{S.RST}"
             )
         else:
             defaults = {
@@ -370,6 +496,9 @@ def interactive_config_menu(
                 "auto_open": "off",
                 "auto_install": "off",
                 "directory_naming": "llm",
+                "tts_voice": "alloy",
+                "tts_format": "mp3",
+                "tts_speed": 1.0,
             }
             changed = any(
                 it["value"] != current_config.get(it["key"], defaults.get(it["key"]))
@@ -381,8 +510,8 @@ def interactive_config_menu(
         buf.append(_box_row(status, w) + "\033[K\n")
 
         hl_parts = ["←→ tab", "↑↓", "Space", "Enter/Tab"]
-        if active_tab == 0:
-            hl_parts.extend(["^A all", "^N none", "[ ] page", "+ add"])
+        if _is_model_tab():
+            hl_parts.extend(["^A tab all", "^N tab none", "[ ] page", "+ add"])
         hl_parts.append("Esc")
         hl = f"{S.DIM}{' · '.join(hl_parts)}{S.RST}"
         buf.append(_box_row(hl, w) + "\033[K\n")
@@ -425,6 +554,7 @@ def interactive_config_menu(
                     mid = add_model_buffer.strip()
                     if mid and mid not in seen_ids:
                         short = _unique_short_name(mid, existing_names)
+                        is_tts = is_tts_model(mid)
                         existing_names.add(short)
                         seen_ids.add(mid)
                         model_items.append(
@@ -433,13 +563,17 @@ def interactive_config_menu(
                                 "id": mid,
                                 "selected": True,
                                 "pricing": "",
+                                "is_tts": is_tts,
                             }
                         )
                         _nat_short_w = max(_nat_short_w, len(short) + 2)
                         _nat_id_w = max(_nat_id_w, len(mid) + 2)
-                        _refresh_model_filter(preserve_current=False)
-                        model_cursor = len(model_items) - 1
-                        _sync_model_page_from_cursor()
+                        added_tab = TTS_TAB if is_tts else MODEL_TAB
+                        _refresh_model_filter(MODEL_TAB, preserve_current=True)
+                        _refresh_model_filter(TTS_TAB, preserve_current=True)
+                        model_cursor[added_tab] = len(model_items) - 1
+                        _sync_model_page_from_cursor(added_tab)
+                        active_tab = added_tab
                     adding_model = False
                     add_model_buffer = ""
                     sys.stdout.write("\033[?25l")
@@ -459,29 +593,30 @@ def interactive_config_menu(
             elif key == "right":
                 active_tab = (active_tab + 1) % len(tabs)
             elif key == "up":
-                if active_tab == 0 and filtered_model_indices:
-                    idx = filtered_model_indices.index(model_cursor)
-                    model_cursor = filtered_model_indices[(idx - 1) % len(filtered_model_indices)]
+                if _is_model_tab() and filtered_model_indices[active_tab]:
+                    indices = filtered_model_indices[active_tab]
+                    idx = indices.index(model_cursor[active_tab])
+                    model_cursor[active_tab] = indices[(idx - 1) % len(indices)]
                     _sync_model_page_from_cursor()
-                elif active_tab != 0:
+                elif active_tab == SETTINGS_TAB:
                     visible = _visible_settings()
                     if visible:
                         settings_cursor = (settings_cursor - 1) % len(visible)
             elif key == "down":
-                if active_tab == 0 and filtered_model_indices:
-                    idx = filtered_model_indices.index(model_cursor)
-                    model_cursor = filtered_model_indices[(idx + 1) % len(filtered_model_indices)]
+                if _is_model_tab() and filtered_model_indices[active_tab]:
+                    indices = filtered_model_indices[active_tab]
+                    idx = indices.index(model_cursor[active_tab])
+                    model_cursor[active_tab] = indices[(idx + 1) % len(indices)]
                     _sync_model_page_from_cursor()
-                elif active_tab != 0:
+                elif active_tab == SETTINGS_TAB:
                     visible = _visible_settings()
                     if visible:
                         settings_cursor = (settings_cursor + 1) % len(visible)
             elif key == "space":
-                if active_tab == 0 and filtered_model_indices:
-                    model_items[model_cursor]["selected"] = not model_items[model_cursor][
-                        "selected"
-                    ]
-                elif active_tab != 0:
+                if _is_model_tab() and filtered_model_indices[active_tab]:
+                    cur = model_cursor[active_tab]
+                    model_items[cur]["selected"] = not model_items[cur]["selected"]
+                elif active_tab == SETTINGS_TAB:
                     visible = _visible_settings()
                     if visible and settings_cursor < len(visible):
                         _, item = visible[settings_cursor]
@@ -499,30 +634,34 @@ def interactive_config_menu(
                             settings_cursor = max(0, len(new_visible) - 1)
             elif key in ("enter", "tab"):
                 break
-            elif key == "ctrl-a" and active_tab == 0:
+            elif key == "ctrl-a" and _is_model_tab():
                 for it in model_items:
-                    it["selected"] = True
-            elif key == "ctrl-n" and active_tab == 0:
+                    if bool(it.get("is_tts")) is (active_tab == TTS_TAB):
+                        it["selected"] = True
+            elif key == "ctrl-n" and _is_model_tab():
                 for it in model_items:
-                    it["selected"] = False
-            elif key in ("[", "]") and active_tab == 0 and filtered_model_indices:
+                    if bool(it.get("is_tts")) is (active_tab == TTS_TAB):
+                        it["selected"] = False
+            elif key in ("[", "]") and _is_model_tab() and filtered_model_indices[active_tab]:
                 pcount = _model_page_count()
                 if key == "[":
-                    model_page = (model_page - 1) % pcount
+                    model_page[active_tab] = (model_page[active_tab] - 1) % pcount
                 else:
-                    model_page = (model_page + 1) % pcount
+                    model_page[active_tab] = (model_page[active_tab] + 1) % pcount
                 start, end = _model_page_bounds()
-                model_cursor = filtered_model_indices[start if start < end else 0]
-            elif key == "+" and active_tab == 0:
+                indices = filtered_model_indices[active_tab]
+                model_cursor[active_tab] = indices[start if start < end else 0]
+            elif key == "+" and _is_model_tab():
                 adding_model = True
+                adding_model_tab = active_tab
                 add_model_buffer = ""
                 sys.stdout.write("\033[?25h")
-            elif active_tab == 0 and key == "backspace":
-                if model_search_query:
-                    model_search_query = model_search_query[:-1]
+            elif _is_model_tab() and key == "backspace":
+                if model_search_query[active_tab]:
+                    model_search_query[active_tab] = model_search_query[active_tab][:-1]
                     _refresh_model_filter(preserve_current=False)
-            elif active_tab == 0 and _is_printable_search_char(key):
-                model_search_query += key
+            elif _is_model_tab() and _is_printable_search_char(key):
+                model_search_query[active_tab] += key
                 _refresh_model_filter(preserve_current=False)
             render()
     finally:

--- a/wavebench/tui/progress/tracker.py
+++ b/wavebench/tui/progress/tracker.py
@@ -79,6 +79,7 @@ class ProgressTracker:
         pricing_lookup: dict[str, Any] | None = None,
         model_id_map: dict[str, str] | None = None,
         alt_screen: bool = False,
+        progress_unit: str = "tokens",
     ):
         self._total = total
         self._results = results
@@ -104,6 +105,7 @@ class ProgressTracker:
         self._pricing_lookup = pricing_lookup or {}
         self._model_id_map = model_id_map or {}
         self._alt_screen = alt_screen and self._is_tty
+        self._progress_unit = progress_unit
         self._entered_alt_screen = False
         self._saved_termios = None
         self._wave_intensity = 0.0
@@ -187,6 +189,8 @@ class ProgressTracker:
 
     def _live_cost_for_active(self, model_name: str, chars: int) -> float | None:
         """Estimate live cost for an in-progress model from streamed chars."""
+        if self._progress_unit == "bytes":
+            return None
         pricing = self._model_pricing(model_name)
         if not pricing:
             return None
@@ -312,6 +316,15 @@ class ProgressTracker:
     # ── internal rendering ────────────────────────────────────────────────
 
     @staticmethod
+    def _format_bytes(num_bytes: float) -> str:
+        """Format byte counts for TTS audio progress."""
+        if num_bytes < 1024:
+            return f"{int(num_bytes)} B"
+        if num_bytes < 1024 * 1024:
+            return f"{num_bytes / 1024:.1f} KiB"
+        return f"{num_bytes / (1024 * 1024):.1f} MiB"
+
+    @staticmethod
     def _phase_boxes(filled: int) -> str:
         """Render a 5-stage inline progress indicator with uniform color that
         shifts from deep blue → bright neon cyan as more boxes fill."""
@@ -323,9 +336,12 @@ class ProgressTracker:
 
     def _token_boxes(self, model_name: str, chars: int) -> str:
         """Boxes based on token progress: each box = 20% of avg tokens."""
-        avg = self._avg_tokens.get(model_name, self.DEFAULT_AVG_TOKENS)
-        est_tokens = chars / 4
-        pct = min(est_tokens / max(avg, 1), 1.0)
+        if self._progress_unit == "bytes":
+            pct = min(chars / (64 * 1024), 1.0)
+        else:
+            avg = self._avg_tokens.get(model_name, self.DEFAULT_AVG_TOKENS)
+            est_tokens = chars / 4
+            pct = min(est_tokens / max(avg, 1), 1.0)
         filled = int(pct * 5)
         if pct > 0 and filled == 0:
             filled = 1
@@ -388,9 +404,15 @@ class ProgressTracker:
             sym = _ok
             usage = info.get("usage", {})
             tokens = usage.get("total_tokens")
+            audio_bytes = usage.get("audio_bytes")
             fname = info.get("file", "")
-            tk_part = f"  {S.DIM}{tokens:,} tk{S.RST}" if tokens else ""
-            detail = f"saved {_arrow} {S.GRN}{fname}{S.RST}{tk_part}{cost_s}{retry_s}"
+            if audio_bytes:
+                usage_part = f"  {S.DIM}{self._format_bytes(audio_bytes)}{S.RST}"
+            elif tokens:
+                usage_part = f"  {S.DIM}{tokens:,} tk{S.RST}"
+            else:
+                usage_part = ""
+            detail = f"saved {_arrow} {S.GRN}{fname}{S.RST}{usage_part}{cost_s}{retry_s}"
         elif st == "cancelled":
             sym = _skip
             detail = f"{S.DIM}cancelled{S.RST}{retry_s}"
@@ -405,7 +427,7 @@ class ProgressTracker:
             overflow = _vlen(content) + 2 + len(t) - inner_w
             max_fname = max(8, len(fname) - overflow)
             fname = _truncate(fname, max_fname)
-            detail = f"saved {_arrow} {S.GRN}{fname}{S.RST}{tk_part}{cost_s}{retry_s}"
+            detail = f"saved {_arrow} {S.GRN}{fname}{S.RST}{usage_part}{cost_s}{retry_s}"
             content = f"{rank_s} {sym} {_rpad(name, self._pad)}  {detail}"
         gap = max(inner_w - _vlen(content) - len(t), 2)
         return f"{content}{' ' * gap}{S.DIM}{t}{S.RST}"
@@ -480,7 +502,7 @@ class ProgressTracker:
                 lines = 0
 
                 wave = _title_wave(idx)
-                buf.append(_box_top(f"Generating \033[22m{wave}", w) + "\033[K\n")
+                buf.append(_box_top(f"{self._label} \033[22m{wave}", w) + "\033[K\n")
                 lines += 1
 
                 od = self._format_output_dir(inner_w)
@@ -559,34 +581,47 @@ class ProgressTracker:
                                     ainfo["last_rate_time"] = now
                                 else:
                                     d_chars = ainfo["chars"] - ainfo["last_chars"]
-                                    instant_tks = (d_chars / 4) / dt
+                                    instant_rate = (
+                                        d_chars / dt
+                                        if self._progress_unit == "bytes"
+                                        else (d_chars / 4) / dt
+                                    )
                                     if ainfo["smoothed_rate"] <= 0:
-                                        ainfo["smoothed_rate"] = instant_tks
+                                        ainfo["smoothed_rate"] = instant_rate
                                     else:
                                         ainfo["smoothed_rate"] = (
-                                            0.3 * instant_tks + 0.7 * ainfo["smoothed_rate"]
+                                            0.3 * instant_rate + 0.7 * ainfo["smoothed_rate"]
                                         )
                                     ainfo["last_chars"] = ainfo["chars"]
                                     ainfo["last_rate_time"] = now
 
                             boxes = self._token_boxes(name, ainfo["chars"])
                             avg_tk = self._avg_tokens.get(name, self.DEFAULT_AVG_TOKENS)
-                            model_scale = avg_tk * 4
+                            model_scale = (
+                                64 * 1024 if self._progress_unit == "bytes" else avg_tk * 4
+                            )
 
                             rate = ainfo["smoothed_rate"]
-                            rf = min(1.0, math.sqrt(max(0.0, rate) / 200.0))
+                            rate_scale = 50_000.0 if self._progress_unit == "bytes" else 200.0
+                            rf = min(1.0, math.sqrt(max(0.0, rate) / rate_scale))
                             spd = 0.12 + 0.33 * rf
                             self._phases[name] = self._phases.get(name, 0.0) + spd
 
-                            est_tk = ainfo["chars"] // 4
                             rate_s = ""
-                            if ainfo["smoothed_rate"] > 0:
-                                rate_s = (
-                                    f"  {_styles.ACCENT}{int(ainfo['smoothed_rate']):,} tk/s{S.RST}"
-                                )
+                            if self._progress_unit == "bytes":
+                                meta = f"{S.DIM}{self._format_bytes(ainfo['chars'])}{S.RST}"
+                                if ainfo["smoothed_rate"] > 0:
+                                    rate_s = (
+                                        f"  {_styles.ACCENT}"
+                                        f"{self._format_bytes(ainfo['smoothed_rate'])}/s{S.RST}"
+                                    )
+                            else:
+                                est_tk = ainfo["chars"] // 4
+                                meta = f"{S.DIM}~{est_tk:,} tk{S.RST}"
+                                if ainfo["smoothed_rate"] > 0:
+                                    rate_s = f"  {_styles.ACCENT}{int(ainfo['smoothed_rate']):,} tk/s{S.RST}"
                             live_c = self._live_cost_for_active(name, ainfo["chars"])
                             cost_s = f"  {S.HYEL}{format_cost(live_c)}{S.RST}" if live_c else ""
-                            meta = f"{S.DIM}~{est_tk:,} tk{S.RST}"
                             time_s = f"  {S.DIM}{mel}{S.RST}"
 
                             pfx = 5 + 3 + self._pad + 2 + 2

--- a/wavebench/tui/tts_player.py
+++ b/wavebench/tui/tts_player.py
@@ -33,7 +33,6 @@ _MPG123_ENC_SIGNED_16 = 0x0D0
 _MPG123_READ_BYTES = 8192
 _ENCODED_PLAYBACK_RATE = 44_100
 _ENCODED_PLAYBACK_CHANNELS = 2
-_LAST_PLAYBACK_HANDLE: Any | None = None
 
 
 class _PulseSampleSpec(ctypes.Structure):
@@ -569,16 +568,6 @@ def _start_audio(filepath: str) -> tuple[bool, Any | None]:
         return True, proc if _managed_player(cmd) else None
     except (OSError, FileNotFoundError):
         return False, None
-
-
-def play_audio(filepath: str) -> bool:
-    """Start playback for *filepath* and return whether a player was launched."""
-    global _LAST_PLAYBACK_HANDLE
-    _stop_audio(_LAST_PLAYBACK_HANDLE)
-    launched, _LAST_PLAYBACK_HANDLE = _start_audio(filepath)
-    if not launched:
-        _LAST_PLAYBACK_HANDLE = None
-    return launched
 
 
 def _tts_items(output_dir: str, results: dict[str, Any]) -> list[tuple[str, str, str]]:

--- a/wavebench/tui/tts_player.py
+++ b/wavebench/tui/tts_player.py
@@ -1,0 +1,671 @@
+"""Small arrow-key TTS output browser/player."""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import os
+import shutil
+import subprocess
+import sys
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+from wavebench.tui import styles as _styles
+from wavebench.tui.input import _read_key_or_resize
+from wavebench.tui.styles import S, _box_bot, _box_row, _box_top, _truncate, _tw
+
+_AUDIO_EXTENSIONS = {".mp3", ".wav", ".m4a", ".aac", ".ogg", ".flac", ".pcm"}
+_NATIVE_AUDIO_EXTENSIONS = {".mp3", ".wav", ".ogg", ".flac", ".pcm"}
+_RAW_PCM_SAMPLE_RATE = 24_000
+_RAW_PCM_CHANNELS = 1
+_RAW_PCM_SAMPLE_WIDTH = 2
+_PULSE_SAMPLE_S16LE = 3
+_PULSE_STREAM_PLAYBACK = 1
+_SFM_READ = 0x10
+_MPG123_OK = 0
+_MPG123_DONE = -12
+_MPG123_NEW_FORMAT = -11
+_MPG123_MONO = 1
+_MPG123_STEREO = 2
+_MPG123_ENC_SIGNED_16 = 0x0D0
+_MPG123_READ_BYTES = 8192
+_ENCODED_PLAYBACK_RATE = 44_100
+_ENCODED_PLAYBACK_CHANNELS = 2
+_LAST_PLAYBACK_HANDLE: Any | None = None
+
+
+class _PulseSampleSpec(ctypes.Structure):
+    _fields_ = [
+        ("format", ctypes.c_int),
+        ("rate", ctypes.c_uint32),
+        ("channels", ctypes.c_uint8),
+    ]
+
+
+class _SndFileInfo(ctypes.Structure):
+    _fields_ = [
+        ("frames", ctypes.c_int64),
+        ("samplerate", ctypes.c_int),
+        ("channels", ctypes.c_int),
+        ("format", ctypes.c_int),
+        ("sections", ctypes.c_int),
+        ("seekable", ctypes.c_int),
+    ]
+
+
+@dataclass(frozen=True)
+class _DecodedPcm:
+    data: bytes
+    sample_rate: int
+    channels: int
+
+
+class _NativeAudioHandle:
+    """Small wrapper that keeps miniaudio objects alive until playback stops."""
+
+    def __init__(self, device: Any, stream: Any) -> None:
+        self.device = device
+        self.stream = stream
+
+    def stop(self) -> None:
+        self.stream = None
+        self.device.close()
+
+
+class _ThreadedAudioHandle:
+    """Managed native playback running on a background thread."""
+
+    def __init__(self, thread: threading.Thread, stop_event: threading.Event) -> None:
+        self.thread = thread
+        self.stop_event = stop_event
+
+    def stop(self) -> None:
+        self.stop_event.set()
+        if self.thread is not threading.current_thread():
+            self.thread.join(timeout=0.5)
+
+
+def _load_miniaudio() -> Any | None:
+    try:
+        import miniaudio
+    except Exception:
+        return None
+    return miniaudio
+
+
+def _load_pulse_simple() -> Any | None:
+    lib_path = ctypes.util.find_library("pulse-simple") or "libpulse-simple.so.0"
+    try:
+        lib = ctypes.CDLL(lib_path)
+    except OSError:
+        return None
+
+    lib.pa_simple_new.argtypes = [
+        ctypes.c_char_p,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_char_p,
+        ctypes.POINTER(_PulseSampleSpec),
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_int),
+    ]
+    lib.pa_simple_new.restype = ctypes.c_void_p
+    lib.pa_simple_write.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_int),
+    ]
+    lib.pa_simple_write.restype = ctypes.c_int
+    lib.pa_simple_drain.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_int)]
+    lib.pa_simple_drain.restype = ctypes.c_int
+    lib.pa_simple_free.argtypes = [ctypes.c_void_p]
+    lib.pa_simple_free.restype = None
+    return lib
+
+
+def _load_sndfile() -> Any | None:
+    lib_path = ctypes.util.find_library("sndfile") or "libsndfile.so.1"
+    try:
+        lib = ctypes.CDLL(lib_path)
+    except OSError:
+        return None
+
+    lib.sf_open.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.POINTER(_SndFileInfo)]
+    lib.sf_open.restype = ctypes.c_void_p
+    lib.sf_readf_short.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_int16), ctypes.c_int64]
+    lib.sf_readf_short.restype = ctypes.c_int64
+    lib.sf_close.argtypes = [ctypes.c_void_p]
+    lib.sf_close.restype = ctypes.c_int
+    return lib
+
+
+def _load_mpg123() -> Any | None:
+    lib_path = ctypes.util.find_library("mpg123") or "libmpg123.so.0"
+    try:
+        lib = ctypes.CDLL(lib_path)
+    except OSError:
+        return None
+
+    try:
+        lib.mpg123_init.restype = ctypes.c_int
+        lib.mpg123_new.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.c_int)]
+        lib.mpg123_new.restype = ctypes.c_void_p
+        lib.mpg123_format_none.argtypes = [ctypes.c_void_p]
+        lib.mpg123_format_none.restype = ctypes.c_int
+        lib.mpg123_format.argtypes = [ctypes.c_void_p, ctypes.c_long, ctypes.c_int, ctypes.c_int]
+        lib.mpg123_format.restype = ctypes.c_int
+        lib.mpg123_open.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+        lib.mpg123_open.restype = ctypes.c_int
+        lib.mpg123_getformat.argtypes = [
+            ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_long),
+            ctypes.POINTER(ctypes.c_int),
+            ctypes.POINTER(ctypes.c_int),
+        ]
+        lib.mpg123_getformat.restype = ctypes.c_int
+        lib.mpg123_read.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_size_t,
+            ctypes.POINTER(ctypes.c_size_t),
+        ]
+        lib.mpg123_read.restype = ctypes.c_int
+        lib.mpg123_close.argtypes = [ctypes.c_void_p]
+        lib.mpg123_close.restype = ctypes.c_int
+        lib.mpg123_delete.argtypes = [ctypes.c_void_p]
+        lib.mpg123_delete.restype = None
+        lib.mpg123_rates.argtypes = [
+            ctypes.POINTER(ctypes.POINTER(ctypes.c_long)),
+            ctypes.POINTER(ctypes.c_size_t),
+        ]
+        lib.mpg123_rates.restype = None
+    except AttributeError:
+        return None
+
+    if lib.mpg123_init() != _MPG123_OK:
+        return None
+    return lib
+
+
+def _decode_sndfile(filepath: str) -> _DecodedPcm | None:
+    lib = _load_sndfile()
+    if lib is None:
+        return None
+
+    info = _SndFileInfo()
+    try:
+        handle = lib.sf_open(os.fsencode(filepath), _SFM_READ, ctypes.byref(info))
+    except Exception:
+        return None
+    if not handle:
+        return None
+
+    chunks: list[bytes] = []
+    try:
+        if info.samplerate <= 0 or info.channels <= 0:
+            return None
+        chunk_frames = max(1, min(info.samplerate, 48_000))
+        buffer = (ctypes.c_int16 * (chunk_frames * info.channels))()
+        while True:
+            frames_read = lib.sf_readf_short(handle, buffer, chunk_frames)
+            if frames_read <= 0:
+                break
+            chunks.append(ctypes.string_at(buffer, frames_read * info.channels * _RAW_PCM_SAMPLE_WIDTH))
+    except Exception:
+        return None
+    finally:
+        lib.sf_close(handle)
+
+    data = b"".join(chunks)
+    if not data:
+        return None
+    return _DecodedPcm(data=data, sample_rate=info.samplerate, channels=info.channels)
+
+
+def _mpg123_rates(lib: Any) -> list[int]:
+    fallback = [8000, 11025, 12000, 16000, 22050, 24000, 32000, 44100, 48000]
+    rates_ptr = ctypes.POINTER(ctypes.c_long)()
+    count = ctypes.c_size_t(0)
+    try:
+        lib.mpg123_rates(ctypes.byref(rates_ptr), ctypes.byref(count))
+    except Exception:
+        return fallback
+    if not rates_ptr or count.value <= 0:
+        return fallback
+    return [int(rates_ptr[idx]) for idx in range(count.value)]
+
+
+def _configure_mpg123_signed16(lib: Any, handle: Any) -> bool:
+    try:
+        if lib.mpg123_format_none(handle) != _MPG123_OK:
+            return False
+        configured = False
+        for rate in _mpg123_rates(lib):
+            ret = lib.mpg123_format(
+                handle,
+                rate,
+                _MPG123_MONO | _MPG123_STEREO,
+                _MPG123_ENC_SIGNED_16,
+            )
+            configured = configured or ret == _MPG123_OK
+        return configured
+    except Exception:
+        return False
+
+
+def _mpg123_format(lib: Any, handle: Any) -> tuple[int, int, int] | None:
+    sample_rate = ctypes.c_long(0)
+    channels = ctypes.c_int(0)
+    encoding = ctypes.c_int(0)
+    try:
+        ret = lib.mpg123_getformat(
+            handle,
+            ctypes.byref(sample_rate),
+            ctypes.byref(channels),
+            ctypes.byref(encoding),
+        )
+    except Exception:
+        return None
+    if ret != _MPG123_OK:
+        return None
+    if sample_rate.value <= 0 or channels.value <= 0:
+        return None
+    if encoding.value != _MPG123_ENC_SIGNED_16:
+        return None
+    return int(sample_rate.value), int(channels.value), int(encoding.value)
+
+
+def _decode_mpg123(filepath: str) -> _DecodedPcm | None:
+    lib = _load_mpg123()
+    if lib is None:
+        return None
+
+    error = ctypes.c_int(0)
+    try:
+        handle = lib.mpg123_new(None, ctypes.byref(error))
+    except Exception:
+        return None
+    if not handle:
+        return None
+
+    try:
+        if not _configure_mpg123_signed16(lib, handle):
+            return None
+        if lib.mpg123_open(handle, os.fsencode(filepath)) != _MPG123_OK:
+            return None
+        fmt = _mpg123_format(lib, handle)
+        if fmt is None:
+            return None
+        sample_rate, channels, _encoding = fmt
+
+        chunks: list[bytes] = []
+        buffer = (ctypes.c_ubyte * _MPG123_READ_BYTES)()
+        while True:
+            bytes_read = ctypes.c_size_t(0)
+            ret = lib.mpg123_read(
+                handle,
+                buffer,
+                _MPG123_READ_BYTES,
+                ctypes.byref(bytes_read),
+            )
+            if bytes_read.value:
+                chunks.append(ctypes.string_at(buffer, bytes_read.value))
+            if ret == _MPG123_DONE:
+                break
+            if ret == _MPG123_NEW_FORMAT:
+                new_fmt = _mpg123_format(lib, handle)
+                if new_fmt is None or new_fmt[:2] != (sample_rate, channels):
+                    return None
+                continue
+            if ret != _MPG123_OK:
+                return None
+    except Exception:
+        return None
+    finally:
+        try:
+            lib.mpg123_close(handle)
+        finally:
+            lib.mpg123_delete(handle)
+
+    data = b"".join(chunks)
+    if not data:
+        return None
+    return _DecodedPcm(data=data, sample_rate=sample_rate, channels=channels)
+
+
+def _decode_encoded_audio(filepath: str) -> _DecodedPcm | None:
+    if os.path.splitext(filepath)[1].lower() == ".mp3":
+        decoded = _decode_mpg123(filepath)
+        if decoded is not None:
+            return decoded
+    return _decode_sndfile(filepath)
+
+
+def _pulse_pcm_worker(
+    lib: Any,
+    pulse_handle: Any,
+    pcm_data: bytes,
+    chunk_bytes: int,
+    stop_event: threading.Event,
+) -> None:
+    error = ctypes.c_int(0)
+    offset = 0
+    try:
+        while offset < len(pcm_data) and not stop_event.is_set():
+            end = min(len(pcm_data), offset + chunk_bytes)
+            chunk = pcm_data[offset:end]
+            if lib.pa_simple_write(pulse_handle, chunk, len(chunk), ctypes.byref(error)) < 0:
+                return
+            offset = end
+        if not stop_event.is_set():
+            lib.pa_simple_drain(pulse_handle, ctypes.byref(error))
+    finally:
+        lib.pa_simple_free(pulse_handle)
+
+
+def _start_pulse_data(
+    pcm_data: bytes,
+    sample_rate: int,
+    channels: int,
+) -> _ThreadedAudioHandle | None:
+    if sys.platform.startswith("win") or sys.platform == "darwin":
+        return None
+    if not pcm_data or sample_rate <= 0 or channels <= 0:
+        return None
+
+    lib = _load_pulse_simple()
+    if lib is None:
+        return None
+
+    error = ctypes.c_int(0)
+    spec = _PulseSampleSpec(_PULSE_SAMPLE_S16LE, sample_rate, channels)
+    pulse_handle = lib.pa_simple_new(
+        None,
+        b"WaveBench",
+        _PULSE_STREAM_PLAYBACK,
+        None,
+        b"TTS output",
+        ctypes.byref(spec),
+        None,
+        None,
+        ctypes.byref(error),
+    )
+    if not pulse_handle:
+        return None
+
+    frame_bytes = channels * _RAW_PCM_SAMPLE_WIDTH
+    chunk_bytes = max(frame_bytes, frame_bytes * (sample_rate // 10))
+    stop_event = threading.Event()
+    thread = threading.Thread(
+        target=_pulse_pcm_worker,
+        args=(lib, pulse_handle, pcm_data, chunk_bytes, stop_event),
+        daemon=True,
+    )
+    thread.start()
+    return _ThreadedAudioHandle(thread, stop_event)
+
+
+def _start_pulse_pcm(filepath: str) -> _ThreadedAudioHandle | None:
+    try:
+        with open(filepath, "rb") as fh:
+            pcm_data = fh.read()
+    except OSError:
+        return None
+    return _start_pulse_data(pcm_data, _RAW_PCM_SAMPLE_RATE, _RAW_PCM_CHANNELS)
+
+
+def _start_pulse_decoded_audio(filepath: str) -> _ThreadedAudioHandle | None:
+    decoded = _decode_encoded_audio(filepath)
+    if decoded is None:
+        return None
+    return _start_pulse_data(decoded.data, decoded.sample_rate, decoded.channels)
+
+
+def _start_native_audio(filepath: str) -> Any | None:
+    """Start audio through WaveBench-native backends when possible."""
+    ext = os.path.splitext(filepath)[1].lower()
+    if ext not in _NATIVE_AUDIO_EXTENSIONS:
+        return None
+
+    if ext == ".pcm":
+        pulse_handle = _start_pulse_pcm(filepath)
+        if pulse_handle is not None:
+            return pulse_handle
+    else:
+        pulse_handle = _start_pulse_decoded_audio(filepath)
+        if pulse_handle is not None:
+            return pulse_handle
+
+    miniaudio = _load_miniaudio()
+    if miniaudio is None:
+        return None
+
+    device = None
+    try:
+        if ext == ".pcm":
+            with open(filepath, "rb") as fh:
+                pcm_data = fh.read()
+            if not pcm_data:
+                return None
+            stream = miniaudio.stream_raw_pcm_memory(
+                pcm_data,
+                nchannels=_RAW_PCM_CHANNELS,
+                sample_width=_RAW_PCM_SAMPLE_WIDTH,
+            )
+            device = miniaudio.PlaybackDevice(
+                output_format=miniaudio.SampleFormat.SIGNED16,
+                nchannels=_RAW_PCM_CHANNELS,
+                sample_rate=_RAW_PCM_SAMPLE_RATE,
+                app_name="WaveBench",
+            )
+        else:
+            stream = miniaudio.stream_file(
+                filepath,
+                output_format=miniaudio.SampleFormat.SIGNED16,
+                nchannels=_ENCODED_PLAYBACK_CHANNELS,
+                sample_rate=_ENCODED_PLAYBACK_RATE,
+            )
+            device = miniaudio.PlaybackDevice(
+                output_format=miniaudio.SampleFormat.SIGNED16,
+                nchannels=_ENCODED_PLAYBACK_CHANNELS,
+                sample_rate=_ENCODED_PLAYBACK_RATE,
+                app_name="WaveBench",
+            )
+        device.start(stream)
+        return _NativeAudioHandle(device, stream)
+    except Exception:
+        if device is not None:
+            try:
+                device.close()
+            except Exception:
+                pass
+        return None
+
+
+def _audio_player_command(filepath: str) -> list[str] | None:
+    """Return a fallback platform command for non-TTS files."""
+    if os.path.splitext(filepath)[1].lower() in _AUDIO_EXTENSIONS:
+        return None
+
+    if sys.platform == "darwin":
+        afplay = shutil.which("afplay")
+        if afplay:
+            return [afplay, filepath]
+        open_bin = shutil.which("open")
+        return [open_bin, filepath] if open_bin else None
+
+    if sys.platform == "win32":
+        return None
+
+    for candidate in ("mpv", "ffplay", "xdg-open"):
+        path = shutil.which(candidate)
+        if not path:
+            continue
+        if candidate == "mpv":
+            return [path, "--really-quiet", "--no-terminal", filepath]
+        if candidate == "ffplay":
+            return [path, "-nodisp", "-autoexit", "-loglevel", "quiet", filepath]
+        return [path, filepath]
+    return None
+
+
+def _managed_player(cmd: list[str]) -> bool:
+    """True when the launched process is the actual audio player."""
+    return os.path.basename(cmd[0]) in {"afplay", "mpv", "ffplay"}
+
+
+def _stop_audio(proc: Any | None) -> None:
+    """Stop a managed audio process if it is still running."""
+    if proc is None:
+        return
+
+    stop = getattr(proc, "stop", None)
+    if callable(stop):
+        try:
+            stop()
+        except Exception:
+            pass
+        return
+
+    poll = getattr(proc, "poll", None)
+    if not callable(poll) or poll() is not None:
+        return
+    try:
+        proc.terminate()
+        proc.wait(timeout=0.5)
+    except Exception:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+
+
+def _start_audio(filepath: str) -> tuple[bool, Any | None]:
+    """Start playback and return (launched, managed_handle_or_none)."""
+    native_handle = _start_native_audio(filepath)
+    if native_handle is not None:
+        return True, native_handle
+
+    try:
+        if os.path.splitext(filepath)[1].lower() in _AUDIO_EXTENSIONS:
+            return False, None
+        if sys.platform == "win32":
+            os.startfile(filepath)  # type: ignore[attr-defined]
+            return True, None
+        cmd = _audio_player_command(filepath)
+        if not cmd:
+            return False, None
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        return True, proc if _managed_player(cmd) else None
+    except (OSError, FileNotFoundError):
+        return False, None
+
+
+def play_audio(filepath: str) -> bool:
+    """Start playback for *filepath* and return whether a player was launched."""
+    global _LAST_PLAYBACK_HANDLE
+    _stop_audio(_LAST_PLAYBACK_HANDLE)
+    launched, _LAST_PLAYBACK_HANDLE = _start_audio(filepath)
+    if not launched:
+        _LAST_PLAYBACK_HANDLE = None
+    return launched
+
+
+def _tts_items(output_dir: str, results: dict[str, Any]) -> list[tuple[str, str, str]]:
+    items: list[tuple[str, str, str]] = []
+    for model_name, info in results.items():
+        if info.get("status") != "success" or not info.get("file"):
+            continue
+        filename = str(info["file"])
+        path = os.path.join(output_dir, filename)
+        ext = os.path.splitext(path)[1].lower()
+        if ext in _AUDIO_EXTENSIONS and os.path.exists(path):
+            items.append((model_name, filename, path))
+    return items
+
+
+def browse_tts_outputs(output_dir: str, results: dict[str, Any]) -> None:
+    """Open a tiny TUI for navigating and playing TTS outputs.
+
+    ↑/↓ changes selection, Enter/Space plays the selected file, Esc/Tab exits.
+    The browser is intentionally skipped outside an interactive terminal.
+    """
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return
+
+    items = _tts_items(output_dir, results)
+    if not items:
+        return
+
+    cursor = 0
+    current_proc: Any | None = None
+    status = f"{S.DIM}Enter/Space to play · Esc to close{S.RST}"
+
+    def render() -> None:
+        nonlocal status
+        term = shutil.get_terminal_size((80, 24))
+        w = _tw() - 4
+        inner = w - 4
+        max_rows = max(1, term.lines - 6)
+        start = min(max(0, cursor - max_rows + 1), max(0, len(items) - max_rows))
+        visible_items = items[start : start + max_rows]
+
+        sys.stdout.write("\033[H")
+        buf: list[str] = []
+        buf.append(_box_top("TTS Outputs", w) + "\033[K\n")
+        for offset, (model_name, filename, _path) in enumerate(visible_items):
+            idx = start + offset
+            marker = f"{_styles.ACCENT_HI}▸{S.RST}" if idx == cursor else " "
+            name = f"{S.BOLD}{model_name}{S.RST}" if idx == cursor else model_name
+            file_s = _truncate(filename, max(12, inner - len(model_name) - 8))
+            row = f"{marker} {name}  {S.DIM}{file_s}{S.RST}"
+            buf.append(_box_row(row, w) + "\033[K\n")
+        if len(items) > max_rows:
+            end = start + len(visible_items)
+            buf.append(_box_row(f"{S.DIM}showing {start + 1}-{end} of {len(items)}{S.RST}", w) + "\033[K\n")
+        else:
+            buf.append(_box_row("", w) + "\033[K\n")
+        buf.append(_box_row(status, w) + "\033[K\n")
+        buf.append(
+            _box_row(f"{S.DIM}↑↓ navigate · Enter/Space play · Esc/Tab close{S.RST}", w)
+            + "\033[K\n"
+        )
+        buf.append(_box_bot(w) + "\033[K")
+        buf.append("\033[J")
+        sys.stdout.write("".join(buf))
+        sys.stdout.flush()
+
+    sys.stdout.write("\033[?1049h\033[?25l")
+    try:
+        render()
+        while True:
+            key = _read_key_or_resize()
+            if key in ("escape", "tab", "ctrl-c"):
+                return
+            if key in ("up", "left"):
+                cursor = (cursor - 1) % len(items)
+            elif key in ("down", "right"):
+                cursor = (cursor + 1) % len(items)
+            elif key in ("enter", "space"):
+                _model_name, filename, path = items[cursor]
+                _stop_audio(current_proc)
+                launched, current_proc = _start_audio(path)
+                if launched:
+                    status = f"{S.HGRN}Playing{S.RST} {filename}"
+                else:
+                    status = f"{S.HRED}No native audio backend found{S.RST}"
+            render()
+    finally:
+        _stop_audio(current_proc)
+        sys.stdout.write("\033[?25h\033[?1049l")
+        sys.stdout.flush()


### PR DESCRIPTION
## Summary
- Add a TTS mode and CLI orchestration for text-to-speech benchmarks
- Add TTS model metadata, pricing/cost support, config-menu handling, and TTS playback helpers
- Add unit/integration coverage for TTS runner, orchestrator, CLI, storage, model scoring, and player behavior

## Validation
- pytest tests/unit/test_main_cli_tts.py tests/unit/test_orchestrator_tts.py tests/unit/test_runner_tts.py tests/unit/test_tts_player.py
- pytest tests
- ruff check .

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new execution mode that hits OpenRouter’s `/audio/speech` endpoint, writes binary artifacts, and introduces native audio playback + new config/menu flows; mistakes could affect run orchestration, file handling, and platform-specific playback behavior.
> 
> **Overview**
> Adds **TTS benchmarking** as a first-class mode (`--mode tts`) with new CLI flags (`--tts-voice`, `--tts-format`, `--tts-speed`), persisted config defaults, and a dedicated `TTSMode` that treats model responses as raw audio bytes.
> 
> Extends the OpenRouter client with `call_tts_speech()` (retry + streamed byte progress) and updates orchestration/runner logic to **filter model selections into text vs TTS sets**, disable reasoning/auto-open for TTS runs, choose provider-compatible voice/format defaults, and record usage/costs based on `input_characters` + `audio_bytes`.
> 
> Introduces a new `tui/tts_player.py` arrow-key browser that plays saved audio via native backends (PulseAudio/miniaudio) and updates the progress UI/config menu to support **separate Models/TTS tabs**, byte-based progress display, and TTS settings. Documentation and tests are expanded to cover the new mode end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c0fab2b8e6143287a769d5e33f868820e978a19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->