### PR TITLE
COR-6: Add first-class Text-to-Image benchmarking mode

### DIFF
--- a/tests/characterization/test_menus_contract.py
+++ b/tests/characterization/test_menus_contract.py
@@ -199,7 +199,7 @@ def test_line_editor_module_exports_read_line_and_tabescape() -> None:
 
 
 def test_config_menu_builds_separate_default_model_tabs() -> None:
-    from wavebench.models import MODEL_MAPPING, TTS_MODEL_MAPPING
+    from wavebench.models import IMAGE_MODEL_MAPPING, MODEL_MAPPING, TTS_MODEL_MAPPING
     from wavebench.tui.menus.config_menu import (
         _build_config_model_items,
         _filter_config_model_indices,
@@ -208,10 +208,14 @@ def test_config_menu_builds_separate_default_model_tabs() -> None:
     items = _build_config_model_items([], {}, {})
     normal_ids = {items[i]["id"] for i in _filter_config_model_indices(items, "", tts=False)}
     tts_ids = {items[i]["id"] for i in _filter_config_model_indices(items, "", tts=True)}
+    image_ids = {items[i]["id"] for i in _filter_config_model_indices(items, "", image=True)}
 
     assert set(MODEL_MAPPING.values()).issubset(normal_ids)
     assert set(TTS_MODEL_MAPPING.values()).issubset(tts_ids)
+    assert set(IMAGE_MODEL_MAPPING.values()).issubset(image_ids)
     assert normal_ids.isdisjoint(tts_ids)
+    assert normal_ids.isdisjoint(image_ids)
+    assert tts_ids.isdisjoint(image_ids)
 
 
 def test_config_menu_seeds_tts_defaults_when_current_mapping_has_only_text() -> None:
@@ -243,6 +247,10 @@ def test_config_menu_filters_catalog_models_into_matching_tabs() -> None:
         [
             {"id": "anthropic/claude-opus-4.6"},
             {"id": "google/gemini-3.1-flash-tts-preview"},
+            {
+                "id": "openai/test-image",
+                "architecture": {"output_modalities": ["image", "text"]},
+            },
         ],
         {},
         pricing_lookup={},
@@ -250,9 +258,13 @@ def test_config_menu_filters_catalog_models_into_matching_tabs() -> None:
 
     normal_matches = [items[i]["id"] for i in _filter_config_model_indices(items, "claude", tts=False)]
     tts_matches = [items[i]["id"] for i in _filter_config_model_indices(items, "tts", tts=True)]
+    image_matches = [
+        items[i]["id"] for i in _filter_config_model_indices(items, "test-image", image=True)
+    ]
 
     assert normal_matches == ["anthropic/claude-opus-4.6"]
     assert "google/gemini-3.1-flash-tts-preview" in tts_matches
+    assert image_matches == ["openai/test-image"]
 
 
 def test_menus_package_exports_public_entries() -> None:

--- a/tests/characterization/test_progress_contract.py
+++ b/tests/characterization/test_progress_contract.py
@@ -126,6 +126,15 @@ def test_progress_tracker_accepts_byte_progress_unit() -> None:
     tracker.unregister("tts_model")
 
 
+def test_progress_tracker_accepts_image_progress_unit() -> None:
+    from wavebench.tui.progress import ProgressTracker
+
+    tracker = ProgressTracker(total=1, results={}, progress_unit="images")
+    tracker.register("image_model")
+    tracker.update("image_model", 1)
+    tracker.unregister("image_model")
+
+
 def test_progress_tracker_result_row_formats_audio_bytes() -> None:
     from wavebench.tui.progress import ProgressTracker
 
@@ -143,6 +152,25 @@ def test_progress_tracker_result_row_formats_audio_bytes() -> None:
     )
 
     assert "4.0 KiB" in row
+
+
+def test_progress_tracker_result_row_formats_image_count() -> None:
+    from wavebench.tui.progress import ProgressTracker
+
+    tracker = ProgressTracker(total=1, results={})
+    row = tracker._format_result_row(
+        "image_model",
+        {
+            "status": "success",
+            "time_s": 1.0,
+            "file": "image_model.png",
+            "usage": {"image_count": 2},
+        },
+        rank=1,
+        inner_w=100,
+    )
+
+    assert "2 images" in row
 
 
 def test_progress_tracker_register_update_unregister() -> None:

--- a/tests/integration/test_api_streaming.py
+++ b/tests/integration/test_api_streaming.py
@@ -189,6 +189,60 @@ async def test_streaming_http_error_raises_runtime_error(
 
 
 # ---------------------------------------------------------------------------
+# Image generation endpoint
+# ---------------------------------------------------------------------------
+
+
+async def test_image_generation_posts_non_streaming_chat_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
+
+    async def handler(request: web.Request) -> web.Response:
+        seen["body"] = await request.json()
+        return web.json_response(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "images": [
+                                {"image_url": {"url": "data:image/png;base64,aGVsbG8="}}
+                            ],
+                        }
+                    }
+                ],
+                "usage": {"total_tokens": 5},
+            }
+        )
+
+    app = web.Application()
+    app.router.add_post("/chat/completions", handler)
+
+    async with _running_server(app) as server:
+        monkeypatch.setattr(api_mod, "API_URL", str(server.make_url("")).rstrip("/"))
+        async with aiohttp.ClientSession() as session:
+            message, usage = await api_mod.call_image_generation(
+                session,
+                api_key="test-key",
+                model_id="openai/test-image",
+                prompt="A wave",
+                modalities=["image", "text"],
+                image_config={"aspect_ratio": "16:9", "image_size": "1K"},
+            )
+
+    assert seen["body"] == {
+        "model": "openai/test-image",
+        "messages": [{"role": "user", "content": "A wave"}],
+        "modalities": ["image", "text"],
+        "stream": False,
+        "image_config": {"aspect_ratio": "16:9", "image_size": "1K"},
+    }
+    assert message["images"][0]["image_url"]["url"].startswith("data:image/png;base64,")
+    assert usage == {"total_tokens": 5}
+
+
+# ---------------------------------------------------------------------------
 # TTS audio endpoint
 # ---------------------------------------------------------------------------
 
@@ -325,7 +379,7 @@ async def test_tts_speech_http_error_raises_runtime_error(
 # ---------------------------------------------------------------------------
 
 
-def test_fetch_top_models_includes_reserved_speech_models(
+def test_fetch_top_models_includes_reserved_speech_and_image_models(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     requested_urls: list[str] = []
@@ -374,15 +428,16 @@ def test_fetch_top_models_includes_reserved_speech_models(
 
     monkeypatch.setattr(api_mod.urllib.request, "urlopen", fake_urlopen)
 
-    models, pricing = api_mod.fetch_top_models("test-key", count=3)
+    models, pricing = api_mod.fetch_top_models("test-key", count=4)
 
     ids = [m["id"] for m in models]
     assert requested_urls == [f"{api_mod.API_URL}/models?output_modalities=all"]
-    assert len(ids) == 3
+    assert len(ids) == 4
     assert "openai/gpt-4o-mini-tts-2025-12-15" in ids
     assert "mistralai/voxtral-mini-tts-2603" in ids
-    assert not {"provider/image", "provider/audio"} & set(ids)
-    assert "provider/image" in pricing  # pricing lookup still covers all models
+    assert "provider/image" in ids
+    assert "provider/audio" not in ids
+    assert pricing["provider/image"]["__output_modalities"] == ["image"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_main_cli_tts.py
+++ b/tests/unit/test_main_cli_tts.py
@@ -17,6 +17,10 @@ def _default_config() -> dict[str, Any]:
         "tts_voice": "alloy",
         "tts_format": "mp3",
         "tts_speed": 1.0,
+        "image_settings": "provider defaults",
+        "image_aspect_ratio": "1:1",
+        "image_size": "1K",
+        "image_model_ids": [],
     }
 
 
@@ -57,4 +61,47 @@ def test_mode_tts_flag_skips_interactive_mode_selector(monkeypatch) -> None:
         "mode": "tts",
         "text": False,
         "api_key": "test-key",
+    }
+
+
+def test_mode_image_accepts_cli_image_flags(monkeypatch) -> None:
+    from wavebench import __main__ as main_mod
+
+    seen: dict[str, Any] = {}
+
+    async def fake_main_async(args, api_key, model_mapping=None, config=None, pricing_lookup=None):
+        seen["mode"] = args.mode
+        seen["prompt"] = args.prompt
+        seen["image_aspect_ratio"] = args.image_aspect_ratio
+        seen["image_size"] = args.image_size
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "wavebench",
+            "--mode",
+            "image",
+            "--prompt",
+            "A wave",
+            "--image-aspect-ratio",
+            "1:1",
+            "--image-size",
+            "2K",
+        ],
+    )
+    monkeypatch.setattr(main_mod, "load_api_key", lambda: "test-key")
+    monkeypatch.setattr(main_mod, "fetch_top_models", lambda *_args, **_kwargs: ([], {}))
+    monkeypatch.setattr(main_mod, "load_models", lambda: None)
+    monkeypatch.setattr(main_mod, "load_config", _default_config)
+    monkeypatch.setattr(main_mod, "apply_theme", lambda _theme: None)
+    monkeypatch.setattr(main_mod, "main_async", fake_main_async)
+
+    main_mod.main()
+
+    assert seen == {
+        "mode": "image",
+        "prompt": "A wave",
+        "image_aspect_ratio": "1:1",
+        "image_size": "2K",
     }

--- a/tests/unit/test_models_scoring.py
+++ b/tests/unit/test_models_scoring.py
@@ -22,9 +22,12 @@ from wavebench.models import (
     _OPENROUTER_UTILITY,
     _TIER1_PROVIDERS,
     _TIER2_PROVIDERS,
+    IMAGE_MODEL_MAPPING,
     MODEL_MAPPING,
     TTS_MODEL_MAPPING,
     _model_score,
+    image_modalities_for_model,
+    is_image_model,
     is_stealth,
     is_tts_model,
     tts_response_format_for_model,
@@ -217,6 +220,37 @@ def test_is_tts_model_false_for_text_model() -> None:
     assert not is_tts_model("anthropic/claude-opus-4.6")
 
 
+# ---------------------------------------------------------------------------
+# Image model classification
+# ---------------------------------------------------------------------------
+
+
+def test_is_image_model_detects_bundled_defaults() -> None:
+    for model_id in IMAGE_MODEL_MAPPING.values():
+        assert is_image_model(model_id)
+
+
+def test_is_image_model_uses_catalog_output_modalities() -> None:
+    assert is_image_model(
+        "vendor/custom",
+        {"architecture": {"output_modalities": ["image"], "input_modalities": ["text"]}},
+    )
+    assert not is_image_model(
+        "vendor/custom",
+        {"architecture": {"output_modalities": ["text"], "input_modalities": ["text"]}},
+    )
+
+
+def test_image_modalities_follow_catalog_metadata_and_fallback() -> None:
+    assert image_modalities_for_model(
+        "vendor/both", {"__output_modalities": ["image", "text"]}
+    ) == ["image", "text"]
+    assert image_modalities_for_model("vendor/image-only", {"__output_modalities": ["image"]}) == [
+        "image"
+    ]
+    assert image_modalities_for_model("vendor/manual") == ["image", "text"]
+
+
 @pytest.mark.parametrize(
     ("model_id", "expected_voice"),
     [
@@ -277,6 +311,19 @@ def test_tts_model_mapping_has_expected_shape() -> None:
         assert isinstance(short_name, str) and short_name
         assert isinstance(full_id, str) and "/" in full_id
         assert is_tts_model(full_id)
+
+
+def test_image_model_mapping_has_expected_shape() -> None:
+    assert isinstance(IMAGE_MODEL_MAPPING, dict)
+    assert set(IMAGE_MODEL_MAPPING.values()) == {
+        "openai/gpt-5.4-image-2",
+        "google/gemini-3.1-flash-image-preview",
+        "sourceful/riverflow-v2-pro",
+    }
+    for short_name, full_id in IMAGE_MODEL_MAPPING.items():
+        assert isinstance(short_name, str) and short_name
+        assert isinstance(full_id, str) and "/" in full_id
+        assert is_image_model(full_id)
 
 
 def test_tier_sets_are_disjoint() -> None:

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -10,10 +10,13 @@ Covers:
 
 from __future__ import annotations
 
+import base64
+
 import pytest
 
-from wavebench.modes import CODE_MODE, MODES, TEXT_MODE, TTS_MODE, ParsedOutput
+from wavebench.modes import CODE_MODE, IMAGE_MODE, MODES, TEXT_MODE, TTS_MODE, ParsedOutput
 from wavebench.modes.code import CodeMode
+from wavebench.modes.image import ImageMode, extract_image_outputs, write_image_gallery
 from wavebench.modes.text import TextMode
 from wavebench.modes.tts import TTSMode
 
@@ -23,13 +26,14 @@ from wavebench.modes.tts import TTSMode
 
 
 def test_registry_contains_both_builtins() -> None:
-    assert set(MODES.keys()) == {"code", "text", "tts"}
+    assert set(MODES.keys()) == {"code", "text", "tts", "image"}
 
 
 def test_registry_maps_name_to_canonical_instance() -> None:
     assert MODES["code"] is CODE_MODE
     assert MODES["text"] is TEXT_MODE
     assert MODES["tts"] is TTS_MODE
+    assert MODES["image"] is IMAGE_MODE
 
 
 def test_code_mode_defaults_disallow_deps() -> None:
@@ -43,6 +47,8 @@ def test_mode_identity_attrs() -> None:
     assert TEXT_MODE.display_name == "Text"
     assert TTS_MODE.name == "tts"
     assert TTS_MODE.display_name == "TTS"
+    assert IMAGE_MODE.name == "image"
+    assert IMAGE_MODE.display_name == "Image"
 
 
 # ---------------------------------------------------------------------------
@@ -241,3 +247,96 @@ def test_text_mode_singleton_identity() -> None:
 def test_tts_mode_singleton_identity() -> None:
     assert MODES["tts"] is TTS_MODE
     assert isinstance(TTS_MODE, TTSMode)
+
+
+# ---------------------------------------------------------------------------
+# ImageMode
+# ---------------------------------------------------------------------------
+
+
+def test_image_mode_frame_prompt_preserves_text_to_image_prompt() -> None:
+    framed = IMAGE_MODE.frame_prompt("  A neon wave at sunset  ")
+    assert framed == "A neon wave at sunset"
+
+
+def test_image_mode_provider_defaults_do_not_send_image_config() -> None:
+    assert IMAGE_MODE.aspect_ratio == "1:1"
+    assert IMAGE_MODE.image_config() is None
+
+
+def test_image_mode_custom_settings_send_image_config() -> None:
+    mode = ImageMode(aspect_ratio="1:1", image_size="2K", custom_settings=True)
+    assert mode.image_config() == {"aspect_ratio": "1:1", "image_size": "2K"}
+
+
+def test_image_mode_extracts_base64_data_urls_and_extensions() -> None:
+    raw = {
+        "content": "assistant text is ignored",
+        "images": [
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,aGVsbG8="},
+            },
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/jpeg;base64,d29ybGQ="},
+            },
+        ],
+    }
+
+    images = extract_image_outputs(raw)
+
+    assert [image.data for image in images] == [b"hello", b"world"]
+    assert [image.extension for image in images] == ["png", "jpg"]
+
+
+def test_image_mode_detects_actual_image_mime_over_data_url_label() -> None:
+    webp = b"RIFF\x04\x00\x00\x00WEBPVP8 "
+    raw = {"image_url": {"url": "data:image/png;base64," + base64.b64encode(webp).decode()}}
+
+    images = extract_image_outputs(raw)
+
+    assert images[0].mime_type == "image/webp"
+    assert images[0].extension == "webp"
+
+
+def test_image_mode_parse_fails_without_valid_data_url() -> None:
+    out = IMAGE_MODE.parse_response({"content": "plain assistant text"})  # type: ignore[arg-type]
+    assert out.parse_ok is False
+    assert out.parse_error == "no valid base64 image data URLs"
+
+
+def test_image_gallery_includes_summary_actions_and_prompt_formatting(tmp_path) -> None:
+    path = write_image_gallery(
+        str(tmp_path),
+        "A neon wave\nwith clouds",
+        {
+            "modelOne": {
+                "status": "success",
+                "images": ["modelOne.png", "modelOne_2.webp"],
+            },
+            "modelTwo": {"status": "failed"},
+        },
+        theme_name="plum",
+    )
+
+    html = (tmp_path / "gallery.html").read_text(encoding="utf-8")
+
+    assert path == str(tmp_path / "gallery.html")
+    assert "2 images" in html
+    assert "1 successful model" in html
+    assert "1 failed model" in html
+    assert '<span class="prompt-label">Prompt</span>' in html
+    assert "white-space: pre-wrap" in html
+    assert 'loading="lazy"' in html
+    assert "Open full size" in html
+    assert "Download" in html
+    assert "modelOne_2.webp" in html
+    assert 'data-theme="plum"' in html
+    assert "--wb-accent-rgb: 153, 0, 204;" in html
+    assert 'id="image-modal"' in html
+    assert 'data-gallery-index="1"' in html
+    assert 'data-action="prev"' in html
+    assert 'data-action="next"' in html
+    assert "ArrowLeft" in html
+    assert "ArrowRight" in html

--- a/tests/unit/test_orchestrator_image.py
+++ b/tests/unit/test_orchestrator_image.py
@@ -1,0 +1,226 @@
+"""Unit coverage for Image-specific orchestration decisions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from wavebench.core import orchestrator as orchestrator_mod
+from wavebench.modes.image import ImageMode
+
+
+def test_resolve_image_mode_uses_cli_options_as_run_only_custom_settings() -> None:
+    args = SimpleNamespace(
+        mode="image",
+        text=False,
+        image_aspect_ratio="1:1",
+        image_size="2K",
+    )
+
+    mode = orchestrator_mod._resolve_mode(
+        args,
+        auto_install="off",
+        config={
+            "image_settings": "provider defaults",
+            "image_aspect_ratio": "1:1",
+            "image_size": "1K",
+        },
+    )
+
+    assert isinstance(mode, ImageMode)
+    assert mode.custom_settings is True
+    assert mode.image_config() == {"aspect_ratio": "1:1", "image_size": "2K"}
+
+
+def test_resolve_image_mode_provider_defaults_do_not_send_config() -> None:
+    args = SimpleNamespace(mode="image", text=False, image_aspect_ratio=None, image_size=None)
+
+    mode = orchestrator_mod._resolve_mode(
+        args,
+        auto_install="off",
+        config={
+            "image_settings": "provider defaults",
+            "image_aspect_ratio": "16:9",
+            "image_size": "1K",
+        },
+    )
+
+    assert isinstance(mode, ImageMode)
+    assert mode.aspect_ratio == "1:1"
+    assert mode.custom_settings is False
+    assert mode.image_config() is None
+
+
+async def test_main_async_image_filters_models_generates_gallery_and_skips_history(
+    tmp_state_dir: Path,
+    monkeypatch,
+) -> None:
+    async def fake_get_directory_name(*_args: Any, **_kwargs: Any) -> str:
+        return "image_outputs"
+
+    seen: list[tuple[str, str, str, str | None, str, list[str] | None]] = []
+
+    async def fake_run_model(
+        mode,
+        session,
+        api_key,
+        name,
+        mid,
+        user_prompt,
+        default_ext,
+        output_dir_task,
+        semaphore,
+        results,
+        pad,
+        tracker,
+        reasoning_effort="high",
+        auto_open="off",
+        auto_install="off",
+        image_modalities=None,
+    ) -> None:
+        seen.append((mode.name, name, mid, reasoning_effort, auto_open, image_modalities))
+        output_dir = await output_dir_task
+        filename = f"{name}.png"
+        Path(output_dir, filename).write_bytes(b"image")
+        results[name] = {
+            "status": "success",
+            "time_s": 0.01,
+            "file": filename,
+            "images": [filename],
+            "usage": {"image_count": 1, "image_bytes": 5},
+            "retries": [],
+        }
+
+    opened: list[str] = []
+    monkeypatch.setattr(orchestrator_mod, "get_directory_name", fake_get_directory_name)
+    monkeypatch.setattr(orchestrator_mod, "run_model", fake_run_model)
+    monkeypatch.setattr(orchestrator_mod, "_open_with_viewer", lambda path: opened.append(path))
+
+    args = SimpleNamespace(
+        prompt="A neon wave",
+        mode="image",
+        text=False,
+        auto_open="after_all",
+        auto_install=None,
+        image_aspect_ratio=None,
+        image_size=None,
+    )
+    mapping = {
+        "textModel": "anthropic/claude-opus-4.6",
+        "imageModel": "openai/gpt-5.4-image-2",
+    }
+
+    await orchestrator_mod.main_async(
+        args,
+        api_key="test-key",
+        model_mapping=mapping,
+        config={
+            "reasoning_effort": "high",
+            "analytics_sort": "runs",
+            "auto_open": "off",
+            "auto_install": "off",
+            "directory_naming": "slug",
+            "image_settings": "provider defaults",
+            "image_aspect_ratio": "1:1",
+            "image_size": "1K",
+            "image_model_ids": [],
+            "theme": "plum",
+        },
+        pricing_lookup={
+            "openai/gpt-5.4-image-2": {"__output_modalities": ["image", "text"]},
+        },
+    )
+
+    out_dir = tmp_state_dir / "benchmarkResults" / "image_outputs"
+    gallery = out_dir / "gallery.html"
+    assert seen == [
+        (
+            "image",
+            "imageModel",
+            "openai/gpt-5.4-image-2",
+            None,
+            "after_all",
+            ["image", "text"],
+        )
+    ]
+    assert gallery.exists()
+    gallery_html = gallery.read_text(encoding="utf-8")
+    assert "imageModel.png" in gallery_html
+    assert 'data-theme="plum"' in gallery_html
+    assert opened == [str(gallery)]
+    assert not (tmp_state_dir / ".benchmark_history.json").exists()
+
+
+async def test_main_async_image_uses_bundled_defaults_when_no_image_models_selected(
+    tmp_state_dir: Path,
+    monkeypatch,
+) -> None:
+    async def fake_get_directory_name(*_args: Any, **_kwargs: Any) -> str:
+        return "image_defaults"
+
+    seen_names: list[str] = []
+
+    async def fake_run_model(
+        mode,
+        session,
+        api_key,
+        name,
+        mid,
+        user_prompt,
+        default_ext,
+        output_dir_task,
+        semaphore,
+        results,
+        pad,
+        tracker,
+        reasoning_effort="high",
+        auto_open="off",
+        auto_install="off",
+        image_modalities=None,
+    ) -> None:
+        seen_names.append(name)
+        output_dir = await output_dir_task
+        filename = f"{name}.png"
+        Path(output_dir, filename).write_bytes(b"image")
+        results[name] = {
+            "status": "success",
+            "time_s": 0.01,
+            "file": filename,
+            "images": [filename],
+            "usage": {"image_count": 1},
+            "retries": [],
+        }
+
+    monkeypatch.setattr(orchestrator_mod, "get_directory_name", fake_get_directory_name)
+    monkeypatch.setattr(orchestrator_mod, "run_model", fake_run_model)
+
+    args = SimpleNamespace(
+        prompt="A wave",
+        mode="image",
+        text=False,
+        auto_open=None,
+        auto_install=None,
+        image_aspect_ratio=None,
+        image_size=None,
+    )
+
+    await orchestrator_mod.main_async(
+        args,
+        api_key="test-key",
+        model_mapping={"textModel": "anthropic/claude-opus-4.6"},
+        config={
+            "reasoning_effort": "high",
+            "analytics_sort": "runs",
+            "auto_open": "off",
+            "auto_install": "off",
+            "directory_naming": "slug",
+            "image_settings": "provider defaults",
+            "image_aspect_ratio": "1:1",
+            "image_size": "1K",
+            "image_model_ids": [],
+        },
+        pricing_lookup={},
+    )
+
+    assert seen_names == ["gpt5.4Image2", "gemini3.1FlashImage", "riverflowV2Pro"]

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -51,9 +51,12 @@ def test_wavebench_storage_public_names() -> None:
 
 def test_wavebench_models_public_names() -> None:
     from wavebench.models import (
+        IMAGE_MODEL_MAPPING,
         MODEL_MAPPING,
         TTS_MODEL_MAPPING,
         _model_score,
+        image_modalities_for_model,
+        is_image_model,
         is_stealth,
         is_tts_model,
         tts_voice_for_model,
@@ -61,9 +64,12 @@ def test_wavebench_models_public_names() -> None:
 
     assert isinstance(MODEL_MAPPING, dict)
     assert isinstance(TTS_MODEL_MAPPING, dict)
+    assert isinstance(IMAGE_MODEL_MAPPING, dict)
     assert callable(_model_score)
     assert callable(is_stealth)
     assert callable(is_tts_model)
+    assert callable(is_image_model)
+    assert callable(image_modalities_for_model)
     assert callable(tts_voice_for_model)
 
 
@@ -71,6 +77,7 @@ def test_wavebench_api_public_names() -> None:
     from wavebench.api import (
         _map_effort,
         _supported_efforts,
+        call_image_generation,
         call_model_async,
         call_model_streaming,
         call_tts_speech,
@@ -79,6 +86,7 @@ def test_wavebench_api_public_names() -> None:
     )
 
     for fn in (
+        call_image_generation,
         call_model_async,
         call_model_streaming,
         call_tts_speech,

--- a/tests/unit/test_runner_image.py
+++ b/tests/unit/test_runner_image.py
@@ -1,0 +1,119 @@
+"""Unit coverage for Image-specific runner behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from wavebench.core import runner as runner_mod
+from wavebench.modes.image import ImageMode
+
+
+class _NoopTracker:
+    is_running = False
+
+
+async def test_run_model_writes_multiple_generated_images_with_detected_extensions(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    seen: dict[str, Any] = {}
+
+    async def fake_call_image_generation(
+        session: Any,
+        api_key: str,
+        model_id: str,
+        prompt: str,
+        modalities: list[str] | None,
+        image_config: dict[str, str] | None,
+        on_retry: Any,
+    ) -> tuple[dict[str, Any], dict]:
+        seen.update(
+            {
+                "model_id": model_id,
+                "prompt": prompt,
+                "modalities": modalities,
+                "image_config": image_config,
+            }
+        )
+        return (
+            {
+                "role": "assistant",
+                "content": "text response ignored",
+                "images": [
+                    {"image_url": {"url": "data:image/png;base64,aGVsbG8="}},
+                    {"image_url": {"url": "data:image/webp;base64,d29ybGQ="}},
+                ],
+            },
+            {"total_tokens": 3},
+        )
+
+    monkeypatch.setattr(runner_mod, "call_image_generation", fake_call_image_generation)
+
+    async def output_dir() -> str:
+        return str(tmp_path)
+
+    results: dict[str, Any] = {}
+    output_dir_task = asyncio.create_task(output_dir())
+
+    await runner_mod.run_model(
+        ImageMode(aspect_ratio="1:1", image_size="2K", custom_settings=True),
+        session=object(),  # type: ignore[arg-type]
+        api_key="test-key",
+        model_name="imageModel",
+        model_id="openai/test-image",
+        user_prompt="A wave",
+        default_ext=".png",
+        output_dir_task=output_dir_task,
+        semaphore=asyncio.Semaphore(1),
+        results=results,
+        pad=12,
+        tracker=_NoopTracker(),
+        reasoning_effort=None,
+        image_modalities=["image", "text"],
+    )
+
+    assert seen == {
+        "model_id": "openai/test-image",
+        "prompt": "A wave",
+        "modalities": ["image", "text"],
+        "image_config": {"aspect_ratio": "1:1", "image_size": "2K"},
+    }
+    assert (tmp_path / "imageModel.png").read_bytes() == b"hello"
+    assert (tmp_path / "imageModel_2.webp").read_bytes() == b"world"
+    assert results["imageModel"]["status"] == "success"
+    assert results["imageModel"]["file"] == "imageModel.png"
+    assert results["imageModel"]["images"] == ["imageModel.png", "imageModel_2.webp"]
+    assert results["imageModel"]["usage"]["image_count"] == 2
+
+
+async def test_run_model_fails_image_without_valid_data_url(tmp_path, monkeypatch) -> None:
+    async def fake_call_image_generation(*_args: Any, **_kwargs: Any) -> tuple[dict[str, Any], dict]:
+        return {"role": "assistant", "content": "plain text only"}, {}
+
+    monkeypatch.setattr(runner_mod, "call_image_generation", fake_call_image_generation)
+
+    async def output_dir() -> str:
+        return str(tmp_path)
+
+    results: dict[str, Any] = {}
+    output_dir_task = asyncio.create_task(output_dir())
+
+    await runner_mod.run_model(
+        ImageMode(),
+        session=object(),  # type: ignore[arg-type]
+        api_key="test-key",
+        model_name="imageModel",
+        model_id="openai/test-image",
+        user_prompt="A wave",
+        default_ext=".png",
+        output_dir_task=output_dir_task,
+        semaphore=asyncio.Semaphore(1),
+        results=results,
+        pad=12,
+        tracker=_NoopTracker(),
+        reasoning_effort=None,
+    )
+
+    assert results["imageModel"]["status"] == "failed"
+    assert not list(tmp_path.iterdir())

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -63,6 +63,10 @@ def test_load_config_missing_file_returns_defaults(tmp_state_dir: Path) -> None:
         "tts_voice": "alloy",
         "tts_format": "mp3",
         "tts_speed": 1.0,
+        "image_settings": "provider defaults",
+        "image_aspect_ratio": "1:1",
+        "image_size": "1K",
+        "image_model_ids": [],
     }
 
 
@@ -79,6 +83,10 @@ def test_save_config_then_load_config_roundtrip(tmp_state_dir: Path) -> None:
     assert loaded["tts_voice"] == "alloy"
     assert loaded["tts_format"] == "mp3"
     assert loaded["tts_speed"] == 1.0
+    assert loaded["image_settings"] == "provider defaults"
+    assert loaded["image_aspect_ratio"] == "1:1"
+    assert loaded["image_size"] == "1K"
+    assert loaded["image_model_ids"] == []
 
 
 def test_load_config_corrupted_json_returns_defaults(tmp_state_dir: Path) -> None:

--- a/wavebench/__main__.py
+++ b/wavebench/__main__.py
@@ -3,7 +3,7 @@
 Parses command-line arguments, loads persistent state (models + config),
 dispatches to either ``core.main_async()`` for a benchmark run or the
 interactive config menu, and prints lifetime analytics on ``--stats``.
-Supports the interactive mode-select screen at startup (Code / Text / TTS / config).
+Supports the interactive mode-select screen at startup (Code / Text / TTS / Image / config).
 """
 
 import argparse
@@ -21,7 +21,13 @@ except ImportError:
 import wavebench.tui.styles as _styles
 from wavebench.api import fetch_top_models, load_api_key
 from wavebench.core import main_async
-from wavebench.models import MODEL_MAPPING, TTS_MODEL_MAPPING, is_tts_model
+from wavebench.models import (
+    IMAGE_MODEL_MAPPING,
+    MODEL_MAPPING,
+    TTS_MODEL_MAPPING,
+    is_image_model,
+    is_tts_model,
+)
 from wavebench.storage import (
     _history_path,
     load_config,
@@ -118,6 +124,29 @@ def main() -> None:
         default=None,
         help="Playback speed multiplier for TTS providers that support it",
     )
+    parser.add_argument(
+        "--image-aspect-ratio",
+        choices=[
+            "1:1",
+            "2:3",
+            "3:2",
+            "3:4",
+            "4:3",
+            "4:5",
+            "5:4",
+            "9:16",
+            "16:9",
+            "21:9",
+        ],
+        default=None,
+        help="Aspect ratio for --mode image (default display: 1:1; implies custom settings)",
+    )
+    parser.add_argument(
+        "--image-size",
+        choices=["1K", "2K", "4K"],
+        default=None,
+        help="Image size for --mode image (default display: 1K; implies custom settings)",
+    )
     parser.add_argument("--stats", action="store_true", help="Show lifetime analytics and exit")
     parser.add_argument("--clear-history", action="store_true", help="Reset analytics history")
     parser.add_argument(
@@ -133,7 +162,10 @@ def main() -> None:
         dest="auto_open",
         choices=["incremental", "after_all"],
         default=None,
-        help="Auto-open generated code/text files (incremental or after_all; TTS uses browser)",
+        help=(
+            "Auto-open generated code/text files "
+            "(incremental or after_all; TTS/image use run viewers)"
+        ),
     )
     parser.add_argument(
         "--auto-install",
@@ -223,7 +255,8 @@ def main() -> None:
             row = (
                 f"{_styles.ACCENT_HI}[1]{S.RST} Code  "
                 f"{_styles.ACCENT}[2]{S.RST} Text  "
-                f"{_styles.ACCENT}[3]{S.RST} TTS"
+                f"{_styles.ACCENT}[3]{S.RST} TTS  "
+                f"{_styles.ACCENT}[4]{S.RST} Image"
                 f"  {_dot}  "
                 f"{S.DIM}{len(active)} models{S.RST}  "
                 f"{_styles.ACCENT}[c]{S.RST} config"
@@ -317,6 +350,10 @@ def main() -> None:
                         sys.stdout.write("3\n")
                         mode_name = "tts"
                         mode_done = True
+                    elif key == "4":
+                        sys.stdout.write("4\n")
+                        mode_name = "image"
+                        mode_done = True
                     elif key == "1":
                         sys.stdout.write("1\n")
                         mode_name = "code"
@@ -324,6 +361,7 @@ def main() -> None:
                 sys.stdout.write("\033[4A\r\033[J")
                 sys.stdout.flush()
 
+            explicit_image_ids = set(config.get("image_model_ids") or [])
             if mode_name == "tts":
                 if selected_models is None:
                     active = TTS_MODEL_MAPPING
@@ -331,11 +369,28 @@ def main() -> None:
                     active = {n: m for n, m in selected_models.items() if is_tts_model(m)}
                     if not active:
                         active = TTS_MODEL_MAPPING
+            elif mode_name == "image":
+                if selected_models is None:
+                    active = IMAGE_MODEL_MAPPING
+                else:
+                    active = {
+                        n: m
+                        for n, m in selected_models.items()
+                        if m in explicit_image_ids or is_image_model(m)
+                    }
+                    if not active:
+                        active = IMAGE_MODEL_MAPPING
             else:
                 if selected_models is None:
                     active = MODEL_MAPPING
                 else:
-                    active = {n: m for n, m in selected_models.items() if not is_tts_model(m)}
+                    active = {
+                        n: m
+                        for n, m in selected_models.items()
+                        if not is_tts_model(m)
+                        and m not in explicit_image_ids
+                        and not is_image_model(m)
+                    }
                     if not active:
                         active = MODEL_MAPPING
             names = list(active.keys())

--- a/wavebench/api.py
+++ b/wavebench/api.py
@@ -10,6 +10,7 @@ Key entry points:
   - ``call_model_async()``  — non-streaming completion
   - ``call_model_streaming()``  — SSE completion with progress callback
   - ``call_tts_speech()``  — raw audio generation via /audio/speech
+  - ``call_image_generation()``  — non-streaming image-output chat completion
   - ``fetch_top_models()``  — sync catalog fetch for the config menu
 """
 
@@ -25,7 +26,7 @@ from typing import Any
 
 import aiohttp
 
-from wavebench.models import _model_score, is_stealth
+from wavebench.models import _model_score, is_image_model, is_stealth
 from wavebench.tui.styles import S, _tri
 
 API_URL = "https://openrouter.ai/api/v1"
@@ -828,6 +829,65 @@ async def call_tts_speech(
     raise RuntimeError(f"HTTP {last_status}: {last_err[:120].strip()}")
 
 
+async def call_image_generation(
+    session: aiohttp.ClientSession,
+    api_key: str,
+    model_id: str,
+    prompt: str,
+    modalities: list[str] | None = None,
+    image_config: dict[str, str] | None = None,
+    on_retry: RetryCallback | None = None,
+) -> tuple[dict[str, Any], dict]:
+    """Generate images through non-streaming /chat/completions.
+
+    Returns the assistant message and usage metadata. Image data URLs are
+    decoded by the image mode/runner so assistant text can be ignored there.
+    """
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "X-Title": "Benchmark Script",
+    }
+    data: dict[str, Any] = {
+        "model": model_id,
+        "messages": [{"role": "user", "content": prompt}],
+        "modalities": modalities or ["image", "text"],
+        "stream": False,
+    }
+    if image_config:
+        data["image_config"] = image_config
+
+    last_status = 0
+    last_err = ""
+    for attempt in range(1, _MAX_RETRIES + 2):
+        retry_wait_s: float | None = None
+        async with session.post(f"{API_URL}/chat/completions", headers=headers, json=data) as resp:
+            if resp.status in _RETRYABLE_STATUSES and attempt <= _MAX_RETRIES:
+                last_status = resp.status
+                last_err = await resp.text()
+                retry_wait_s = _retry_wait_seconds(resp.headers.get("Retry-After"), attempt)
+                if on_retry:
+                    on_retry(last_status, attempt, _MAX_RETRIES, retry_wait_s)
+            elif resp.status != 200:
+                text = await resp.text()
+                raise RuntimeError(f"HTTP {resp.status}: {text[:120].strip()}")
+            else:
+                try:
+                    body = await resp.json()
+                    message = body["choices"][0]["message"]
+                except (KeyError, IndexError, json.JSONDecodeError) as exc:
+                    raise RuntimeError(f"parse error: {exc}")
+                if not isinstance(message, dict):
+                    raise RuntimeError("parse error: assistant message was not an object")
+                return message, body.get("usage", {})
+
+        if retry_wait_s is not None:
+            await asyncio.sleep(retry_wait_s)
+            continue
+
+    raise RuntimeError(f"HTTP {last_status}: {last_err[:120].strip()}")
+
+
 def fetch_top_models(api_key: str, count: int = 12) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Fetch models from OpenRouter, returning (top_for_menu, pricing_lookup).
 
@@ -850,18 +910,26 @@ def fetch_top_models(api_key: str, count: int = 12) -> tuple[list[dict[str, Any]
 
     all_models = data.get("data", [])
 
-    # Build pricing lookup for every model
+    # Build pricing/metadata lookup for every model. The extra private keys are
+    # ignored by cost computation but let image mode choose OpenRouter modalities
+    # from catalog metadata when available.
     pricing_lookup = {}
     for m in all_models:
         mid = m.get("id", "")
         if mid:
-            pricing_lookup[mid] = m.get("pricing", {})
+            arch = m.get("architecture", {}) or {}
+            pricing_lookup[mid] = {
+                **(m.get("pricing", {}) or {}),
+                "__output_modalities": arch.get("output_modalities") or [],
+                "__input_modalities": arch.get("input_modalities") or [],
+            }
 
-    # Filter candidates for the menu. Include regular text-output models plus
-    # speech-output models so TTS models can be selected from the same browser.
+    # Filter candidates for the menu. Include regular text-output models,
+    # speech-output models for TTS, and image-output models for Image mode.
     seen_slugs = set()
     filtered = []
     speech_filtered = []
+    image_filtered = []
     for m in all_models:
         mid = m.get("id", "")
         arch = m.get("architecture", {})
@@ -869,12 +937,13 @@ def fetch_top_models(api_key: str, count: int = 12) -> tuple[list[dict[str, Any]
         in_mods = arch.get("input_modalities") or []
         has_text_output = "text" in out_mods
         has_speech_output = "speech" in out_mods
+        has_image_output = "image" in out_mods or is_image_model(mid, m)
 
-        # Must accept text input and produce either text or speech output.
-        if "text" not in in_mods or not (has_text_output or has_speech_output):
+        # Must accept text input and produce a supported output modality.
+        if "text" not in in_mods or not (has_text_output or has_speech_output or has_image_output):
             continue
-        # Skip image/audio-output models; dedicated TTS models advertise speech.
-        if "audio" in out_mods or "image" in out_mods:
+        # Skip audio-output models that are not dedicated speech/TTS models.
+        if "audio" in out_mods and not has_speech_output:
             continue
         # Skip :free duplicate variants (keep the paid original)
         if ":free" in mid:
@@ -892,16 +961,23 @@ def fetch_top_models(api_key: str, count: int = 12) -> tuple[list[dict[str, Any]
             continue
         seen_slugs.add(slug)
 
-        if has_speech_output:
+        if has_image_output:
+            image_filtered.append(m)
+        elif has_speech_output:
             speech_filtered.append(m)
         else:
             filtered.append(m)
 
-    # Sort by popularity score descending. Reserve a small slice for speech
-    # models so the config menu exposes TTS choices even when the text catalog
-    # has more than *count* high-scoring entries.
+    # Sort by popularity score descending. Reserve slices for speech/image
+    # models so each dedicated config tab has useful catalog rows.
     filtered.sort(key=_model_score, reverse=True)
     speech_filtered.sort(key=_model_score, reverse=True)
-    speech_count = min(len(speech_filtered), count, 20)
-    text_count = max(0, count - speech_count)
-    return filtered[:text_count] + speech_filtered[:speech_count], pricing_lookup
+    image_filtered.sort(key=_model_score, reverse=True)
+    image_count = min(len(image_filtered), count, 20)
+    speech_count = min(len(speech_filtered), max(0, count - image_count), 20)
+    text_count = max(0, count - image_count - speech_count)
+    return (
+        filtered[:text_count]
+        + speech_filtered[:speech_count]
+        + image_filtered[:image_count]
+    ), pricing_lookup

--- a/wavebench/core/orchestrator.py
+++ b/wavebench/core/orchestrator.py
@@ -19,6 +19,7 @@ import wavebench.tui.styles as _styles
 from wavebench.api import _is_effort_naming_bridge, _map_effort, _supported_efforts
 from wavebench.modes import MODES, Mode
 from wavebench.modes.code import CodeMode
+from wavebench.modes.image import ImageMode, write_image_gallery
 from wavebench.modes.tts import TTSMode
 from wavebench.parsers import get_directory_name
 from wavebench.storage import load_history, record_run
@@ -87,6 +88,19 @@ def _resolve_mode(args: Any, auto_install: str, config: dict[str, Any] | None = 
             speed=speed,
         )
 
+    def _configured_image_mode() -> ImageMode:
+        cli_aspect = getattr(args, "image_aspect_ratio", None)
+        cli_size = getattr(args, "image_size", None)
+        config_custom = config.get("image_settings") == "custom"
+        custom = bool(cli_aspect or cli_size) or config_custom
+        aspect_ratio = cli_aspect or (config.get("image_aspect_ratio") if config_custom else None)
+        image_size = cli_size or (config.get("image_size") if config_custom else None)
+        return ImageMode(
+            aspect_ratio=str(aspect_ratio or "1:1"),
+            image_size=str(image_size or "1K"),
+            custom_settings=custom,
+        )
+
     explicit = getattr(args, "mode", None)
     if explicit:
         mode = MODES.get(explicit)
@@ -95,6 +109,8 @@ def _resolve_mode(args: Any, auto_install: str, config: dict[str, Any] | None = 
                 return CodeMode(allow_deps=True)
             if mode.name == "tts":
                 return _configured_tts_mode()
+            if mode.name == "image":
+                return _configured_image_mode()
             return mode
 
     if getattr(args, "text", False):
@@ -110,7 +126,14 @@ async def main_async(
     config: dict[str, Any] | None = None,
     pricing_lookup: dict[str, Any] | None = None,
 ) -> None:
-    from wavebench.models import MODEL_MAPPING, TTS_MODEL_MAPPING, is_tts_model
+    from wavebench.models import (
+        IMAGE_MODEL_MAPPING,
+        MODEL_MAPPING,
+        TTS_MODEL_MAPPING,
+        image_modalities_for_model,
+        is_image_model,
+        is_tts_model,
+    )
 
     if config is None:
         from wavebench.storage import load_config
@@ -136,12 +159,19 @@ async def main_async(
     mode = _resolve_mode(args, auto_install, config)
     text_mode = mode.name == "text"
     tts_mode = mode.name == "tts"
+    image_mode = mode.name == "image"
     if tts_mode:
         reasoning_effort = None
         # Avoid launching every generated audio file when a user has auto-open
         # enabled for code/text runs; TTS has its own post-run browser/player.
         auto_open = "off"
+    if image_mode:
+        reasoning_effort = None
+        if auto_open == "incremental":
+            print(f"  {_skip} {S.DIM}incremental auto-open is ignored for image mode.{S.RST}")
+            auto_open = "off"
 
+    explicit_image_ids = set(config.get("image_model_ids") or [])
     if tts_mode:
         if model_mapping is None:
             mapping = TTS_MODEL_MAPPING
@@ -149,17 +179,37 @@ async def main_async(
             mapping = {name: mid for name, mid in model_mapping.items() if is_tts_model(mid)}
             if not mapping:
                 mapping = TTS_MODEL_MAPPING
+    elif image_mode:
+        if model_mapping is None:
+            mapping = IMAGE_MODEL_MAPPING
+        else:
+            _pricing = pricing_lookup or {}
+            mapping = {
+                name: mid
+                for name, mid in model_mapping.items()
+                if mid in explicit_image_ids or is_image_model(mid, _pricing.get(mid, {}))
+            }
+            if not mapping:
+                mapping = IMAGE_MODEL_MAPPING
     else:
         if model_mapping is None:
             mapping = MODEL_MAPPING
         else:
-            mapping = {name: mid for name, mid in model_mapping.items() if not is_tts_model(mid)}
+            mapping = {
+                name: mid
+                for name, mid in model_mapping.items()
+                if not is_tts_model(mid)
+                and mid not in explicit_image_ids
+                and not is_image_model(mid, (pricing_lookup or {}).get(mid, {}))
+            }
             if not mapping:
                 mapping = MODEL_MAPPING
     pad = max((len(n) for n in mapping), default=12) + 1
 
     if tts_mode:
         default_ext = f".{getattr(mode, 'response_format', 'mp3')}"
+    elif image_mode:
+        default_ext = ".png"
     elif text_mode:
         default_ext = ".md"
     else:
@@ -210,6 +260,13 @@ async def main_async(
                 heavy=True,
             )
         )
+    elif image_mode:
+        settings = "custom" if getattr(mode, "custom_settings", False) else "provider defaults"
+        details = (
+            f"{settings} "
+            f"({getattr(mode, 'aspect_ratio', '1:1')}, {getattr(mode, 'image_size', '1K')})"
+        )
+        print(_box_row(f"{S.DIM}{'IMAGE':>8}{S.RST}  {details}", w, heavy=True))
     else:
         print(_box_row(f"{S.DIM}{'REASON':>8}{S.RST}  {reasoning_label}", w, heavy=True))
     print(_box_row(f"{S.DIM}{'NAMING':>8}{S.RST}  {directory_naming}", w, heavy=True))
@@ -219,7 +276,7 @@ async def main_async(
     # Build per-model effort-adjustment notices; these get scrolled as a
     # news-ticker on the summary line once the tracker starts rendering.
     effort_ticker_msgs: list = []
-    if reasoning_effort and not tts_mode:
+    if reasoning_effort and not tts_mode and not image_mode:
         for _name, model_id in targets:
             supported = _supported_efforts(model_id)
             short_id = model_id.split("/", 1)[-1]
@@ -262,7 +319,7 @@ async def main_async(
             results,
             pad=pad,
             label="Synthesizing" if tts_mode else "Generating",
-            progress_unit="bytes" if tts_mode else "tokens",
+            progress_unit="bytes" if tts_mode else ("images" if image_mode else "tokens"),
             model_names=model_names,
             avg_tokens=avg_tokens,
             pricing_lookup=pricing_lookup or {},
@@ -297,29 +354,48 @@ async def main_async(
             output_dir_task = asyncio.create_task(resolve_output_dir())
             await tracker.start()
 
-            tasks = [
-                run_model(
-                    mode,
-                    session,
-                    api_key,
-                    name,
-                    mid,
-                    user_prompt,
-                    default_ext,
-                    output_dir_task,
-                    semaphore,
-                    results,
-                    pad,
-                    tracker,
-                    reasoning_effort=reasoning_effort,
-                    auto_open=auto_open,
-                    auto_install=auto_install,
+            def _run_model_task(name: str, mid: str) -> asyncio.Task:
+                kwargs: dict[str, Any] = {
+                    "reasoning_effort": reasoning_effort,
+                    "auto_open": auto_open,
+                    "auto_install": auto_install,
+                }
+                if image_mode:
+                    kwargs["image_modalities"] = image_modalities_for_model(
+                        mid, (pricing_lookup or {}).get(mid, {})
+                    )
+                return asyncio.create_task(
+                    run_model(
+                        mode,
+                        session,
+                        api_key,
+                        name,
+                        mid,
+                        user_prompt,
+                        default_ext,
+                        output_dir_task,
+                        semaphore,
+                        results,
+                        pad,
+                        tracker,
+                        **kwargs,
+                    )
                 )
-                for name, mid in targets
-            ]
+
+            tasks = [_run_model_task(name, mid) for name, mid in targets]
             await asyncio.gather(*tasks, return_exceptions=True)
 
-            if auto_open == "after_all" and output_dir_task.done():
+            if image_mode and output_dir_task.done():
+                out = output_dir_task.result()
+                gallery_path = write_image_gallery(
+                    out,
+                    user_prompt,
+                    results,
+                    theme_name=str(config.get("theme", "default")),
+                )
+                if auto_open == "after_all":
+                    _open_with_viewer(gallery_path)
+            elif auto_open == "after_all" and output_dir_task.done():
                 out = output_dir_task.result()
                 code_tabs: list[tuple] = []
                 for name, info in results.items():
@@ -402,9 +478,13 @@ async def main_async(
                 usage_d = info.get("usage", {})
                 tokens = usage_d.get("total_tokens")
                 audio_bytes = usage_d.get("audio_bytes")
+                image_count = usage_d.get("image_count")
                 fname = info["file"]
                 if audio_bytes:
                     usage_part = f"  {S.DIM}{ProgressTracker._format_bytes(audio_bytes)}{S.RST}"
+                elif image_count:
+                    label = "image" if image_count == 1 else "images"
+                    usage_part = f"  {S.DIM}{image_count} {label}{S.RST}"
                 elif tokens:
                     usage_part = f"  {S.DIM}{tokens:,} tk{S.RST}"
                 else:
@@ -443,17 +523,20 @@ async def main_async(
         print(_box_bot(w))
 
     # ── Record run & show lifetime analytics ───────────────────────────────
-    run_costs = {name: _result_cost(name, info) for name, info in results.items()}
-    record_run(
-        history,
-        user_prompt,
-        output_dir_final[0],
-        total_time,
-        results,
-        costs=run_costs,
-        reasoning_effort=raw_effort if not tts_mode else None,
-    )
-    display_analytics(history, compact=True, pad=pad, sort_by=config.get("analytics_sort", "runs"))
+    if not image_mode:
+        run_costs = {name: _result_cost(name, info) for name, info in results.items()}
+        record_run(
+            history,
+            user_prompt,
+            output_dir_final[0],
+            total_time,
+            results,
+            costs=run_costs,
+            reasoning_effort=raw_effort if not tts_mode else None,
+        )
+        display_analytics(
+            history, compact=True, pad=pad, sort_by=config.get("analytics_sort", "runs")
+        )
     if tts_mode and output_dir_final[0]:
         from wavebench.tui.tts_player import browse_tts_outputs
 

--- a/wavebench/core/runner.py
+++ b/wavebench/core/runner.py
@@ -1,9 +1,9 @@
 """Per-model benchmark runner and the filename utility it shares.
 
 ``run_model`` is the single mode-parameterized driver that streams an
-LLM response (or TTS audio bytes), parses it via the supplied
-:class:`~wavebench.modes.Mode`, writes the output file, and (for code mode)
-optionally detects Python
+LLM response (or TTS audio bytes), or calls an image model non-streaming,
+parses it via the supplied :class:`~wavebench.modes.Mode`, writes the output
+file(s), and (for code mode) optionally detects Python
 dependencies and installs them into a shared per-output-dir venv.
 
 Previously this module held a ``process_model`` / ``process_model_text``
@@ -25,9 +25,10 @@ from typing import Any
 
 import aiohttp
 
-from wavebench.api import call_model_streaming, call_tts_speech
+from wavebench.api import call_image_generation, call_model_streaming, call_tts_speech
 from wavebench.models import tts_response_format_for_model, tts_voice_for_model
 from wavebench.modes import Mode, ParsedOutput
+from wavebench.modes.image import extract_image_outputs
 from wavebench.tui.styles import (
     S,
     _arrow,
@@ -83,17 +84,19 @@ async def run_model(
     reasoning_effort: str | None = "high",
     auto_open: str = "off",
     auto_install: str = "off",
+    image_modalities: list[str] | None = None,
 ) -> None:
     """Execute one model against *mode*; write output; record result.
 
     ``mode.frame_prompt`` wraps *user_prompt* with mode-specific
     instructions; ``mode.parse_response`` converts the raw streamed
     response/audio into a :class:`~wavebench.modes.ParsedOutput` whose
-    ``extension`` drives the saved file's suffix.
+    ``extension`` drives the saved file's suffix. Image mode instead decodes
+    one or more base64 data URLs from a non-streaming chat response.
 
     When ``mode.name == "code"`` AND ``auto_install == "on"`` AND the
     parsed extension is ``py``, dependency detection + venv setup fire
-    as before. Text and TTS modes skip that branch entirely.
+    as before. Text, TTS, and image modes skip that branch entirely.
     """
     start = time.monotonic()
     registered = tracker.is_running
@@ -104,7 +107,7 @@ async def run_model(
         print(f"  {_wait} {model_name:<{pad}}  {S.DIM}calling {model_id}…{S.RST}")
 
     framed_prompt = mode.frame_prompt(user_prompt)
-    content: str | bytes | None = None
+    content: Any = None
     usage: dict = {}
     retry_events: list[dict[str, Any]] = []
     effective_tts_format = getattr(mode, "response_format", "mp3")
@@ -143,6 +146,16 @@ async def run_model(
                     response_format=effective_tts_format,
                     speed=getattr(mode, "speed", 1.0),
                     on_progress=_on_progress,
+                    on_retry=_on_retry,
+                )
+            elif mode.name == "image":
+                content, usage = await call_image_generation(
+                    session,
+                    api_key,
+                    model_id,
+                    framed_prompt,
+                    modalities=image_modalities,
+                    image_config=mode.image_config(),  # type: ignore[attr-defined]
                     on_retry=_on_retry,
                 )
             else:
@@ -249,6 +262,62 @@ async def run_model(
         print(f"  {_work} {model_name:<{pad}}  {S.DIM}{action}…{S.RST}")
 
     try:
+        if mode.name == "image":
+            images = extract_image_outputs(content)
+            if not images:
+                elapsed = time.monotonic() - start
+                if not registered:
+                    print(
+                        f"  {_fail} {model_name:<{pad}}  "
+                        f"{S.RED}no valid images{S.RST}  "
+                        f"{S.DIM}[{format_duration(elapsed)}]{S.RST}"
+                    )
+                results[model_name] = {
+                    "status": "failed",
+                    "time_s": elapsed,
+                    "file": None,
+                    "usage": usage,
+                    "retries": retry_events,
+                }
+                return
+
+            output_dir = await output_dir_task
+            filenames: list[str] = []
+            total_bytes = 0
+            for idx, image in enumerate(images, 1):
+                suffix = "" if idx == 1 else f"_{idx}"
+                filename = get_unique_filename(
+                    output_dir, f"{model_name}{suffix}", image.extension
+                )
+                filepath = os.path.join(output_dir, filename)
+                with open(filepath, "wb") as fh:
+                    fh.write(image.data)
+                filenames.append(filename)
+                total_bytes += len(image.data)
+
+            elapsed = time.monotonic() - start
+            usage = {
+                **usage,
+                "image_count": len(filenames),
+                "image_bytes": total_bytes,
+            }
+            if not registered:
+                more = f" (+{len(filenames) - 1})" if len(filenames) > 1 else ""
+                print(
+                    f"  {_ok} {S.BOLD}{model_name:<{pad}}{S.RST}  "
+                    f"saved {_arrow} {S.GRN}{filenames[0]}{S.RST}{more}  "
+                    f"{S.DIM}[{format_duration(elapsed)}]{S.RST}"
+                )
+            results[model_name] = {
+                "status": "success",
+                "time_s": elapsed,
+                "file": filenames[0],
+                "images": filenames,
+                "usage": usage,
+                "retries": retry_events,
+            }
+            return
+
         parsed = mode.parse_response(content)
         if mode.name == "tts" and parsed.parse_ok:
             parsed = ParsedOutput(

--- a/wavebench/models.py
+++ b/wavebench/models.py
@@ -1,10 +1,11 @@
 """Default model mapping and ranking algorithm.
 
-Holds the fallback ``MODEL_MAPPING`` and ``TTS_MODEL_MAPPING`` used when no
-persistent selection exists, and ``_model_score()`` — the heuristic that ranks
-the OpenRouter catalog by provider tier, pricing, recency, reasoning/tool
-capability, and context length. Also exposes ``is_stealth()`` and
-``is_tts_model()`` classifiers plus TTS provider defaults.
+Holds the fallback ``MODEL_MAPPING``, ``TTS_MODEL_MAPPING``, and
+``IMAGE_MODEL_MAPPING`` used when no persistent selection exists, and
+``_model_score()`` — the heuristic that ranks the OpenRouter catalog by
+provider tier, pricing, recency, reasoning/tool capability, and context
+length. Also exposes ``is_stealth()``, ``is_tts_model()``, and
+``is_image_model()`` classifiers plus TTS provider defaults.
 """
 
 import time
@@ -26,6 +27,12 @@ TTS_MODEL_MAPPING: dict[str, str] = {
     "zonosV0.1Transformer": "zyphra/zonos-v0.1-transformer",
     "orpheus3b": "canopylabs/orpheus-3b-0.1-ft",
     "kokoro82m": "hexgrad/kokoro-82m",
+}
+
+IMAGE_MODEL_MAPPING: dict[str, str] = {
+    "gpt5.4Image2": "openai/gpt-5.4-image-2",
+    "gemini3.1FlashImage": "google/gemini-3.1-flash-image-preview",
+    "riverflowV2Pro": "sourceful/riverflow-v2-pro",
 }
 
 _TIER1_PROVIDERS: frozenset[str] = frozenset(
@@ -66,6 +73,20 @@ _KNOWN_TTS_MODEL_IDS: frozenset[str] = frozenset(
 _TTS_ID_MARKERS: frozenset[str] = frozenset(
     {"tts", "speech", "voxtral", "zonos", "csm-1b", "orpheus", "kokoro"}
 )
+_KNOWN_IMAGE_MODEL_IDS: frozenset[str] = frozenset(IMAGE_MODEL_MAPPING.values())
+_IMAGE_ID_MARKERS: frozenset[str] = frozenset(
+    {
+        "image",
+        "imagen",
+        "flux",
+        "riverflow",
+        "stable-diffusion",
+        "dall-e",
+        "seedream",
+        "hidream",
+        "qwen-image",
+    }
+)
 _DEFAULT_TTS_VOICE_BY_MARKER: tuple[tuple[str, str], ...] = (
     ("google/", "Kore"),
     ("mistralai/voxtral", "en_paul_neutral"),
@@ -81,10 +102,47 @@ _DEFAULT_TTS_FORMAT_BY_MARKER: tuple[tuple[str, str], ...] = (
 )
 
 
+def output_modalities_from_metadata(metadata: dict | None) -> list[str]:
+    """Return OpenRouter output modalities from catalog metadata when present."""
+    if not metadata:
+        return []
+    mods = metadata.get("__output_modalities") or metadata.get("output_modalities")
+    if not mods:
+        arch = metadata.get("architecture") or {}
+        if isinstance(arch, dict):
+            mods = arch.get("output_modalities")
+    if not isinstance(mods, list):
+        return []
+    return [str(m).lower() for m in mods if m]
+
+
 def is_tts_model(model_id: str) -> bool:
     """Heuristic for user-configured models that target speech synthesis."""
     lower = model_id.lower()
     return lower in _KNOWN_TTS_MODEL_IDS or any(marker in lower for marker in _TTS_ID_MARKERS)
+
+
+def is_image_model(model_id: str, metadata: dict | None = None) -> bool:
+    """True for models that generate image outputs.
+
+    Catalog metadata is authoritative when available. For bundled/manual
+    models, fall back to known IDs and conservative image-generation markers.
+    """
+    out_mods = output_modalities_from_metadata(metadata)
+    if out_mods:
+        return "image" in out_mods
+    lower = model_id.lower()
+    return lower in _KNOWN_IMAGE_MODEL_IDS or any(marker in lower for marker in _IMAGE_ID_MARKERS)
+
+
+def image_modalities_for_model(model_id: str, metadata: dict | None = None) -> list[str]:
+    """Return the OpenRouter ``modalities`` value for an image generation model."""
+    out_mods = output_modalities_from_metadata(metadata)
+    if "image" in out_mods:
+        if "text" in out_mods:
+            return ["image", "text"]
+        return ["image"]
+    return ["image", "text"]
 
 
 def tts_voice_for_model(model_id: str, configured_voice: str) -> str:

--- a/wavebench/modes/__init__.py
+++ b/wavebench/modes/__init__.py
@@ -9,9 +9,10 @@ across ``process_model``/``process_model_text``:
     :class:`ParsedOutput` (content, extension, pass/fail).
 
 Concrete modes live in ``code.py`` (``CodeMode``), ``text.py``
-(``TextMode``), and ``tts.py`` (``TTSMode``). The ``MODES`` registry is
-populated on import and keyed by each mode's ``name`` for CLI lookup
-(``--mode code``, ``--mode text``, ``--mode tts``).
+(``TextMode``), ``tts.py`` (``TTSMode``), and ``image.py`` (``ImageMode``).
+The ``MODES`` registry is populated on import and keyed by each mode's
+``name`` for CLI lookup (``--mode code``, ``--mode text``, ``--mode tts``,
+``--mode image``).
 
 ## Adding a new mode
 
@@ -91,15 +92,18 @@ def register(mode: Mode) -> None:
 
 # ── Built-in modes ───────────────────────────────────────────────────────
 from .code import CODE_MODE  # noqa: E402  (avoid circular import)
+from .image import IMAGE_MODE  # noqa: E402
 from .text import TEXT_MODE  # noqa: E402
 from .tts import TTS_MODE  # noqa: E402
 
 register(CODE_MODE)
 register(TEXT_MODE)
 register(TTS_MODE)
+register(IMAGE_MODE)
 
 __all__ = [
     "CODE_MODE",
+    "IMAGE_MODE",
     "MODES",
     "TEXT_MODE",
     "TTS_MODE",

--- a/wavebench/modes/image.py
+++ b/wavebench/modes/image.py
@@ -1,0 +1,420 @@
+"""Image mode — text-to-image generation via OpenRouter chat completions.
+
+Image models return generated images as base64 data URLs in the assistant
+message. This module extracts and validates those URLs, leaving any assistant
+text ignored.
+"""
+
+from __future__ import annotations
+
+import base64
+import html
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from wavebench.modes import ParsedOutput
+from wavebench.tui.styles import THEMES
+
+_IMAGE_DATA_URL_RE = re.compile(
+    r"data:(image/[A-Za-z0-9.+-]+);base64,([A-Za-z0-9+/=\r\n]+)",
+    re.IGNORECASE,
+)
+
+_EXTENSION_BY_MIME = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/webp": "webp",
+    "image/gif": "gif",
+}
+
+
+@dataclass(frozen=True)
+class DecodedImage:
+    """A generated image decoded from an assistant-message data URL."""
+
+    data: bytes
+    mime_type: str
+    extension: str
+
+
+@dataclass(frozen=True)
+class ImageMode:
+    """Text-to-image mode using OpenRouter image-output chat models."""
+
+    name: str = "image"
+    display_name: str = "Image"
+    aspect_ratio: str = "1:1"
+    image_size: str = "1K"
+    custom_settings: bool = False
+
+    def frame_prompt(self, user_prompt: str) -> str:
+        return user_prompt.strip()
+
+    def image_config(self) -> dict[str, str] | None:
+        """Return provider image_config only when custom settings are enabled."""
+        if not self.custom_settings:
+            return None
+        return {
+            "aspect_ratio": self.aspect_ratio,
+            "image_size": self.image_size,
+        }
+
+    def parse_response(self, raw: str | bytes) -> ParsedOutput:
+        images = extract_image_outputs(raw)
+        if not images:
+            return ParsedOutput(
+                content=b"",
+                extension="png",
+                parse_ok=False,
+                parse_error="no valid base64 image data URLs",
+            )
+        first = images[0]
+        return ParsedOutput(
+            content=first.data,
+            extension=first.extension,
+            parse_ok=True,
+        )
+
+
+def _extension_for_mime(mime_type: str) -> str:
+    mime = mime_type.lower()
+    if mime in _EXTENSION_BY_MIME:
+        return _EXTENSION_BY_MIME[mime]
+    subtype = mime.split("/", 1)[-1].split("+", 1)[0]
+    subtype = re.sub(r"[^a-z0-9]", "", subtype)
+    return subtype or "img"
+
+
+def _detect_mime_from_bytes(data: bytes) -> str | None:
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if data.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def _decode_data_url(mime_type: str, payload: str) -> DecodedImage | None:
+    cleaned = "".join(payload.split())
+    try:
+        data = base64.b64decode(cleaned, validate=True)
+    except Exception:
+        return None
+    if not data:
+        return None
+    mime = _detect_mime_from_bytes(data) or mime_type.lower()
+    return DecodedImage(data=data, mime_type=mime, extension=_extension_for_mime(mime))
+
+
+def _extract_from_string(value: str) -> list[DecodedImage]:
+    images: list[DecodedImage] = []
+    for match in _IMAGE_DATA_URL_RE.finditer(value):
+        decoded = _decode_data_url(match.group(1), match.group(2))
+        if decoded is not None:
+            images.append(decoded)
+    return images
+
+
+def extract_image_outputs(response: Any) -> list[DecodedImage]:
+    """Find valid base64 image data URLs anywhere in an assistant message.
+
+    OpenRouter normalizes generated images as data URLs in the assistant
+    message. Providers can place them under ``message.images``, inside a
+    multimodal ``content`` array, or in text-like fields, so this walks the
+    response recursively and ignores all non-image text.
+    """
+    images: list[DecodedImage] = []
+
+    def add_from_string(text: str) -> None:
+        images.extend(_extract_from_string(text))
+
+    def walk(value: Any) -> None:
+        if isinstance(value, str):
+            add_from_string(value)
+        elif isinstance(value, bytes):
+            return
+        elif isinstance(value, dict):
+            for child in value.values():
+                walk(child)
+        elif isinstance(value, (list, tuple)):
+            for child in value:
+                walk(child)
+
+    walk(response)
+    return images
+
+
+def _rgb_csv(color: tuple[int, int, int]) -> str:
+    return ", ".join(str(channel) for channel in color)
+
+
+def _scale_rgb(color: tuple[int, int, int], factor: float, floor: int = 0) -> tuple[int, int, int]:
+    return (
+        max(floor, min(255, int(color[0] * factor))),
+        max(floor, min(255, int(color[1] * factor))),
+        max(floor, min(255, int(color[2] * factor))),
+    )
+
+
+def _gallery_theme_vars(theme_name: str) -> tuple[str, str]:
+    """Return the resolved TUI theme name and CSS variables for the gallery."""
+    resolved_name = theme_name if theme_name in THEMES else "default"
+    theme = THEMES[resolved_name]
+    pulse = theme["pulse"]
+    pulse_dim = theme["pulse_dim"]
+    border = theme["border"]
+    variables = {
+        "bg-rgb": _rgb_csv(_scale_rgb(pulse_dim, 0.12, floor=3)),
+        "bg-soft-rgb": _rgb_csv(_scale_rgb(border, 0.35, floor=8)),
+        "panel-rgb": _rgb_csv(_scale_rgb(border, 0.55, floor=12)),
+        "border-rgb": _rgb_csv(border),
+        "accent-rgb": _rgb_csv(pulse[6]),
+        "accent-hi-rgb": _rgb_csv(pulse[8]),
+        "glow-rgb": _rgb_csv(pulse[3]),
+    }
+    css = "\n".join(f"      --wb-{key}: {value};" for key, value in variables.items())
+    return resolved_name, css
+
+
+def write_image_gallery(
+    output_dir: str,
+    prompt: str,
+    results: dict[str, Any],
+    theme_name: str = "default",
+) -> str:
+    """Write a combined run-level ``gallery.html`` for successful image outputs."""
+    cards: list[str] = []
+    gallery_images: list[dict[str, str]] = []
+    successful_models = 0
+    failed_models = 0
+    image_count = 0
+
+    for model_name, info in results.items():
+        if info.get("status") != "success":
+            failed_models += 1
+            continue
+
+        successful_models += 1
+        files = info.get("images") or ([info.get("file")] if info.get("file") else [])
+        valid_files = [str(filename) for filename in files if filename]
+        image_count += len(valid_files)
+
+        for idx, filename in enumerate(valid_files, 1):
+            suffix = f" #{idx}" if len(valid_files) > 1 else ""
+            label = f"{model_name}{suffix}"
+            gallery_index = len(gallery_images)
+            gallery_images.append(
+                {
+                    "src": filename,
+                    "label": label,
+                    "filename": filename,
+                }
+            )
+            rel = html.escape(filename, quote=True)
+            model_label = html.escape(str(model_name), quote=False)
+            model_alt = html.escape(str(model_name), quote=True)
+            filename_label = html.escape(filename, quote=False)
+            suffix_label = html.escape(suffix, quote=False)
+            cards.append(
+                "<figure class=\"card\">"
+                f"<button class=\"preview\" type=\"button\" data-gallery-index=\"{gallery_index}\" "
+                f"aria-label=\"Open preview for {model_alt}{html.escape(suffix, quote=True)}\">"
+                f"<img src=\"{rel}\" alt=\"{model_alt}{html.escape(suffix, quote=True)}\" "
+                "loading=\"lazy\" decoding=\"async\">"
+                "</button>"
+                "<figcaption>"
+                f"<strong>{model_label}{suffix_label}</strong>"
+                f"<span class=\"filename\">{filename_label}</span>"
+                "<span class=\"actions\">"
+                f"<a href=\"{rel}\" target=\"_blank\" rel=\"noopener\">Open full size</a>"
+                f"<a href=\"{rel}\" download>Download</a>"
+                "</span>"
+                "</figcaption>"
+                "</figure>"
+            )
+
+    body = "\n".join(cards) or '<p class="empty">No images generated.</p>'
+    prompt_html = html.escape(prompt, quote=False)
+    stats = [
+        f"{image_count} image{'s' if image_count != 1 else ''}",
+        f"{successful_models} successful model{'s' if successful_models != 1 else ''}",
+    ]
+    if failed_models:
+        stats.append(f"{failed_models} failed model{'s' if failed_models != 1 else ''}")
+    stats_html = "".join(f'<span class="stat">{html.escape(stat)}</span>' for stat in stats)
+    resolved_theme, theme_vars = _gallery_theme_vars(theme_name)
+    images_json = json.dumps(gallery_images, ensure_ascii=False).replace("</", "<\\/")
+    content = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>WaveBench Image Gallery</title>
+  <style>
+    :root {
+      color-scheme: dark;
+__THEME_VARS__
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: rgb(var(--wb-bg-rgb)); color: #eef2ff; }
+    body.modal-open { overflow: hidden; }
+    body::before { content: ""; position: fixed; inset: 0; z-index: -1; background: radial-gradient(circle at top left, rgba(var(--wb-glow-rgb), 0.28), transparent 34rem), radial-gradient(circle at top right, rgba(var(--wb-accent-rgb), 0.18), transparent 30rem); }
+    header { padding: 2rem; border-bottom: 1px solid rgb(var(--wb-border-rgb)); background: linear-gradient(135deg, rgba(var(--wb-panel-rgb), 0.96), rgba(var(--wb-bg-soft-rgb), 0.86)); }
+    .shell { max-width: 1180px; margin: 0 auto; }
+    h1 { margin: 0 0 0.75rem; font-size: clamp(1.8rem, 3vw, 2.6rem); letter-spacing: -0.04em; }
+    .stats { display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 0 0 1rem; }
+    .stat { display: inline-flex; align-items: center; border: 1px solid rgba(var(--wb-border-rgb), 0.9); border-radius: 999px; padding: 0.3rem 0.65rem; background: rgba(var(--wb-bg-soft-rgb), 0.86); color: #d1d5db; font-size: 0.88rem; }
+    .prompt-card { margin: 0; border: 1px solid rgba(var(--wb-border-rgb), 0.95); border-radius: 16px; padding: 1rem; background: rgba(var(--wb-panel-rgb), 0.74); }
+    .prompt-label { display: block; margin-bottom: 0.35rem; color: rgb(var(--wb-accent-hi-rgb)); font-size: 0.75rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
+    .prompt { margin: 0; color: #e5e7eb; line-height: 1.55; white-space: pre-wrap; }
+    main { padding: 2rem; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.25rem; }
+    .card { margin: 0; border: 1px solid rgba(var(--wb-border-rgb), 0.95); border-radius: 18px; overflow: hidden; background: rgba(var(--wb-panel-rgb), 0.92); box-shadow: 0 20px 48px rgba(0, 0, 0, 0.34); }
+    .preview { display: block; width: 100%; padding: 0; border: 0; background: rgb(var(--wb-bg-rgb)); cursor: zoom-in; }
+    .preview:focus-visible { outline: 3px solid rgb(var(--wb-accent-hi-rgb)); outline-offset: -3px; }
+    .card img { display: block; width: 100%; height: auto; }
+    figcaption { display: grid; gap: 0.45rem; padding: 0.9rem 1rem 1rem; color: #e5e7eb; font-size: 0.95rem; }
+    .filename { color: #a1a1aa; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.82rem; overflow-wrap: anywhere; }
+    .actions { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-top: 0.15rem; }
+    .actions a, .modal-link { color: rgb(var(--wb-accent-hi-rgb)); text-decoration: none; font-weight: 600; }
+    .actions a:hover, .modal-link:hover { color: rgb(var(--wb-accent-rgb)); text-decoration: underline; }
+    .empty { margin: 0; border: 1px dashed rgba(var(--wb-border-rgb), 0.95); border-radius: 16px; padding: 2rem; color: #a1a1aa; text-align: center; background: rgba(var(--wb-panel-rgb), 0.55); }
+    .modal[hidden] { display: none; }
+    .modal { position: fixed; inset: 0; z-index: 10; display: grid; place-items: center; padding: 1rem; background: rgba(0, 0, 0, 0.84); backdrop-filter: blur(6px); }
+    .modal-frame { position: relative; display: grid; grid-template-rows: minmax(0, 1fr) auto; gap: 0.9rem; width: min(96vw, 1200px); max-height: 94vh; border: 1px solid rgb(var(--wb-border-rgb)); border-radius: 22px; padding: 1rem; background: rgba(var(--wb-panel-rgb), 0.96); box-shadow: 0 28px 80px rgba(0, 0, 0, 0.55); }
+    .modal-image-wrap { display: grid; place-items: center; min-height: 0; }
+    .modal-image { display: block; max-width: 100%; max-height: 76vh; border-radius: 14px; background: rgb(var(--wb-bg-rgb)); object-fit: contain; }
+    .modal-caption { display: grid; gap: 0.35rem; padding: 0 0.25rem; }
+    .modal-title { color: #f8fafc; font-weight: 700; }
+    .modal-filename { color: #a1a1aa; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.86rem; overflow-wrap: anywhere; }
+    .modal-actions { display: flex; flex-wrap: wrap; gap: 0.8rem; }
+    .modal-close, .modal-nav { border: 1px solid rgba(var(--wb-border-rgb), 0.95); color: #f8fafc; background: rgba(var(--wb-bg-soft-rgb), 0.92); cursor: pointer; }
+    .modal-close:hover, .modal-nav:hover, .modal-close:focus-visible, .modal-nav:focus-visible { border-color: rgb(var(--wb-accent-hi-rgb)); color: rgb(var(--wb-accent-hi-rgb)); }
+    .modal-close { position: absolute; top: 0.75rem; right: 0.75rem; width: 2.25rem; height: 2.25rem; border-radius: 999px; font-size: 1.35rem; line-height: 1; }
+    .modal-nav { position: absolute; top: 50%; transform: translateY(-50%); width: 2.75rem; height: 3.75rem; border-radius: 999px; font-size: 2rem; line-height: 1; }
+    .modal-prev { left: 0.75rem; }
+    .modal-next { right: 0.75rem; }
+    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+    @media (max-width: 640px) { header, main { padding: 1rem; } .grid { grid-template-columns: 1fr; } .modal-frame { padding: 0.75rem; } .modal-nav { width: 2.25rem; height: 3rem; } }
+  </style>
+</head>
+<body data-theme="__THEME_NAME__">
+  <header>
+    <div class="shell">
+      <h1>WaveBench Image Gallery</h1>
+      <div class="stats" aria-label="Run summary">__STATS_HTML__</div>
+      <section class="prompt-card" aria-label="Prompt">
+        <span class="prompt-label">Prompt</span>
+        <p class="prompt">__PROMPT_HTML__</p>
+      </section>
+    </div>
+  </header>
+  <main><section class="shell grid" aria-label="Generated images">__BODY__</section></main>
+  <div class="modal" id="image-modal" role="dialog" aria-modal="true" aria-label="Generated image preview" aria-hidden="true" hidden>
+    <div class="modal-frame">
+      <button class="modal-close" type="button" data-action="close" aria-label="Close preview">×</button>
+      <button class="modal-nav modal-prev" type="button" data-action="prev" aria-label="Previous image">‹</button>
+      <button class="modal-nav modal-next" type="button" data-action="next" aria-label="Next image">›</button>
+      <div class="modal-image-wrap"><img class="modal-image" id="modal-image" alt=""></div>
+      <div class="modal-caption">
+        <span class="modal-title" id="modal-title"></span>
+        <span class="modal-filename" id="modal-filename"></span>
+        <span class="modal-actions">
+          <a class="modal-link" id="modal-open" target="_blank" rel="noopener">Open full size</a>
+          <a class="modal-link" id="modal-download" download>Download</a>
+        </span>
+      </div>
+    </div>
+  </div>
+  <script>
+    (() => {
+      const images = __IMAGES_JSON__;
+      const modal = document.getElementById('image-modal');
+      const modalImage = document.getElementById('modal-image');
+      const modalTitle = document.getElementById('modal-title');
+      const modalFilename = document.getElementById('modal-filename');
+      const modalOpen = document.getElementById('modal-open');
+      const modalDownload = document.getElementById('modal-download');
+      const closeButton = modal.querySelector('[data-action="close"]');
+      let currentIndex = 0;
+
+      function showImage(index) {
+        if (!images.length) return;
+        currentIndex = (index + images.length) % images.length;
+        const image = images[currentIndex];
+        modalImage.src = image.src;
+        modalImage.alt = image.label;
+        modalTitle.textContent = image.label;
+        modalFilename.textContent = image.filename;
+        modalOpen.href = image.src;
+        modalDownload.href = image.src;
+        modalDownload.setAttribute('download', image.filename);
+      }
+
+      function openModal(index) {
+        if (!images.length) return;
+        showImage(index);
+        modal.hidden = false;
+        modal.setAttribute('aria-hidden', 'false');
+        document.body.classList.add('modal-open');
+        closeButton.focus();
+      }
+
+      function closeModal() {
+        modal.hidden = true;
+        modal.setAttribute('aria-hidden', 'true');
+        document.body.classList.remove('modal-open');
+      }
+
+      document.querySelectorAll('[data-gallery-index]').forEach((button) => {
+        button.addEventListener('click', () => openModal(Number(button.dataset.galleryIndex || 0)));
+      });
+
+      modal.querySelector('[data-action="prev"]').addEventListener('click', () => showImage(currentIndex - 1));
+      modal.querySelector('[data-action="next"]').addEventListener('click', () => showImage(currentIndex + 1));
+      closeButton.addEventListener('click', closeModal);
+      modal.addEventListener('click', (event) => {
+        if (event.target === modal) closeModal();
+      });
+      document.addEventListener('keydown', (event) => {
+        if (modal.hidden) return;
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          closeModal();
+        }
+        if (event.key === 'ArrowLeft') {
+          event.preventDefault();
+          showImage(currentIndex - 1);
+        }
+        if (event.key === 'ArrowRight') {
+          event.preventDefault();
+          showImage(currentIndex + 1);
+        }
+      });
+    })();
+  </script>
+</body>
+</html>
+"""
+    content = (
+        content.replace("__THEME_VARS__", theme_vars)
+        .replace("__THEME_NAME__", html.escape(resolved_theme, quote=True))
+        .replace("__STATS_HTML__", stats_html)
+        .replace("__PROMPT_HTML__", prompt_html)
+        .replace("__BODY__", body)
+        .replace("__IMAGES_JSON__", images_json)
+    )
+    path = os.path.join(output_dir, "gallery.html")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(content)
+    return path
+
+
+IMAGE_MODE = ImageMode()

--- a/wavebench/storage.py
+++ b/wavebench/storage.py
@@ -74,6 +74,10 @@ def load_config() -> dict[str, Any]:
         "tts_voice": "alloy",
         "tts_format": "mp3",
         "tts_speed": 1.0,
+        "image_settings": "provider defaults",
+        "image_aspect_ratio": "1:1",
+        "image_size": "1K",
+        "image_model_ids": [],
     }
     if os.path.exists(path):
         try:

--- a/wavebench/tui/menus/config_menu.py
+++ b/wavebench/tui/menus/config_menu.py
@@ -1,4 +1,4 @@
-"""Tabbed configuration menu — Models/TTS tabs (catalog browser + manual add)
+"""Tabbed configuration menu — Models/TTS/Image tabs (catalog browser + manual add)
 and Settings tab (theme, reasoning-effort, analytics sort, directory naming,
 auto-open, auto-install).
 
@@ -20,7 +20,13 @@ import sys
 from typing import Any
 
 from wavebench.api import fetch_top_models
-from wavebench.models import MODEL_MAPPING, TTS_MODEL_MAPPING, is_tts_model
+from wavebench.models import (
+    IMAGE_MODEL_MAPPING,
+    MODEL_MAPPING,
+    TTS_MODEL_MAPPING,
+    is_image_model,
+    is_tts_model,
+)
 from wavebench.parsers import _DIRECTORY_NAMING_CHOICES
 from wavebench.tui import styles as _styles
 from wavebench.tui.input import _read_key_or_resize
@@ -51,32 +57,62 @@ except ImportError:
 _HAS_SIGWINCH = hasattr(signal, "SIGWINCH")
 
 
+def _model_category(model_id: str, metadata: dict[str, Any] | None = None) -> str:
+    """Return the config-tab category for a model id."""
+    if is_image_model(model_id, metadata):
+        return "image"
+    if is_tts_model(model_id):
+        return "tts"
+    return "model"
+
+
 def _build_config_model_items(
     available_models: list[dict[str, Any]],
     current_mapping: dict[str, str],
     pricing_lookup: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
-    """Build config-menu model rows with text and TTS defaults separated."""
+    """Build config-menu model rows with text, TTS, and Image defaults separated."""
     pricing_lookup = pricing_lookup or {}
     items: list[dict[str, Any]] = []
     seen_ids: set[str] = set()
     existing_names: set[str] = set()
-    category_counts = {False: 0, True: 0}
+    category_counts = {"model": 0, "tts": 0, "image": 0}
 
     selected_pairs = list(current_mapping.items())
     selected_ids = {model_id for _, model_id in selected_pairs}
-    if not any(not is_tts_model(model_id) for _, model_id in selected_pairs):
+    if not any(
+        _model_category(model_id, pricing_lookup.get(model_id, {})) == "model"
+        for _, model_id in selected_pairs
+    ):
         for short_name, model_id in MODEL_MAPPING.items():
             if model_id not in selected_ids:
                 selected_pairs.append((short_name, model_id))
                 selected_ids.add(model_id)
-    if not any(is_tts_model(model_id) for _, model_id in selected_pairs):
+    if not any(
+        _model_category(model_id, pricing_lookup.get(model_id, {})) == "tts"
+        for _, model_id in selected_pairs
+    ):
         for short_name, model_id in TTS_MODEL_MAPPING.items():
             if model_id not in selected_ids:
                 selected_pairs.append((short_name, model_id))
                 selected_ids.add(model_id)
+    if not any(
+        _model_category(model_id, pricing_lookup.get(model_id, {})) == "image"
+        for _, model_id in selected_pairs
+    ):
+        for short_name, model_id in IMAGE_MODEL_MAPPING.items():
+            if model_id not in selected_ids:
+                selected_pairs.append((short_name, model_id))
+                selected_ids.add(model_id)
 
-    def add_item(short_name: str, model_id: str, *, selected: bool) -> int | None:
+    def add_item(
+        short_name: str,
+        model_id: str,
+        *,
+        selected: bool,
+        metadata: dict[str, Any] | None = None,
+        category_override: str | None = None,
+    ) -> int | None:
         if not model_id or model_id in seen_ids:
             return None
         if selected and short_name and short_name not in existing_names:
@@ -85,15 +121,18 @@ def _build_config_model_items(
             short = _unique_short_name(model_id, existing_names)
         seen_ids.add(model_id)
         existing_names.add(short)
-        is_tts = is_tts_model(model_id)
-        category_counts[is_tts] += 1
+        metadata = metadata or pricing_lookup.get(model_id, {})
+        category = category_override or _model_category(model_id, metadata)
+        category_counts[category] += 1
         items.append(
             {
                 "short": short,
                 "id": model_id,
                 "selected": selected,
                 "pricing": _format_price(pricing_lookup.get(model_id, {})),
-                "is_tts": is_tts,
+                "category": category,
+                "is_tts": category == "tts",
+                "is_image": category == "image",
             }
         )
         return len(items) - 1
@@ -103,19 +142,20 @@ def _build_config_model_items(
 
     for m in available_models:
         mid = m.get("id", "")
-        is_tts = is_tts_model(mid)
-        if category_counts[is_tts] >= MODEL_MENU_LIMIT or mid in seen_ids:
+        category = _model_category(mid, m)
+        if category_counts[category] >= MODEL_MENU_LIMIT or mid in seen_ids:
             continue
-        add_item("", mid, selected=False)
+        add_item("", mid, selected=False, metadata=m, category_override=category)
 
     return items
 
 
 def _filter_config_model_indices(
-    items: list[dict[str, Any]], query: str, *, tts: bool
+    items: list[dict[str, Any]], query: str, *, tts: bool = False, image: bool = False
 ) -> list[int]:
     """Return model row indices for one config-menu model tab."""
-    tab_indices = [i for i, item in enumerate(items) if bool(item.get("is_tts")) is tts]
+    category = "image" if image else ("tts" if tts else "model")
+    tab_indices = [i for i, item in enumerate(items) if item.get("category") == category]
     needle = query.strip().lower()
     if not needle:
         return tab_indices
@@ -142,9 +182,10 @@ def interactive_config_menu(
     pricing_lookup = pricing_lookup or {}
     MODEL_TAB = 0
     TTS_TAB = 1
-    SETTINGS_TAB = 2
-    MODEL_TABS = (MODEL_TAB, TTS_TAB)
-    tabs = ["Models", "TTS", "Settings"]
+    IMAGE_TAB = 2
+    SETTINGS_TAB = 3
+    MODEL_TABS = (MODEL_TAB, TTS_TAB, IMAGE_TAB)
+    tabs = ["Models", "TTS", "Image", "Settings"]
     active_tab = MODEL_TAB
 
     model_items = _build_config_model_items(available_models, current_mapping, pricing_lookup)
@@ -177,6 +218,26 @@ def interactive_config_menu(
         "af_alloy",
     ]
     TTS_SPEED_CHOICES = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0]
+    IMAGE_ASPECT_RATIO_CHOICES = [
+        "1:1",
+        "2:3",
+        "3:2",
+        "3:4",
+        "4:3",
+        "4:5",
+        "5:4",
+        "9:16",
+        "16:9",
+        "21:9",
+    ]
+    IMAGE_SIZE_CHOICES = ["1K", "2K", "4K"]
+    image_settings_value = current_config.get("image_settings", "provider defaults")
+    if image_settings_value == "custom":
+        image_aspect_ratio_value = current_config.get("image_aspect_ratio", "1:1")
+        image_size_value = current_config.get("image_size", "1K")
+    else:
+        image_aspect_ratio_value = "1:1"
+        image_size_value = "1K"
 
     settings_items = [
         {
@@ -236,6 +297,31 @@ def interactive_config_menu(
             "choices": TTS_SPEED_CHOICES,
         },
         {
+            "key": "image_settings",
+            "label": "Image settings",
+            "value": image_settings_value,
+            "type": "cycle",
+            "choices": ["provider defaults", "custom"],
+        },
+        {
+            "key": "image_aspect_ratio",
+            "label": "Image aspect ratio",
+            "value": image_aspect_ratio_value,
+            "type": "cycle",
+            "choices": IMAGE_ASPECT_RATIO_CHOICES,
+            "parent_key": "image_settings",
+            "parent_hidden_when": "provider defaults",
+        },
+        {
+            "key": "image_size",
+            "label": "Image size",
+            "value": image_size_value,
+            "type": "cycle",
+            "choices": IMAGE_SIZE_CHOICES,
+            "parent_key": "image_settings",
+            "parent_hidden_when": "provider defaults",
+        },
+        {
             "key": "auto_install",
             "label": "Auto-install deps",
             "value": current_config.get("auto_install", "off"),
@@ -259,12 +345,19 @@ def interactive_config_menu(
             visible.append((i, item))
         return visible
 
+    def _model_tab_category(tab: int) -> str:
+        if tab == TTS_TAB:
+            return "tts"
+        if tab == IMAGE_TAB:
+            return "image"
+        return "model"
+
     model_cursor = {
         tab: next(
             (
                 i
                 for i, item in enumerate(model_items)
-                if bool(item.get("is_tts")) is (tab == TTS_TAB)
+                if item.get("category") == _model_tab_category(tab)
             ),
             0,
         )
@@ -272,11 +365,12 @@ def interactive_config_menu(
     }
     _CHROME_LINES = 8
     model_page_size = max(1, min(14, shutil.get_terminal_size((80, 24)).lines - _CHROME_LINES))
-    model_page = {MODEL_TAB: 0, TTS_TAB: 0}
-    model_search_query = {MODEL_TAB: "", TTS_TAB: ""}
+    model_page = {MODEL_TAB: 0, TTS_TAB: 0, IMAGE_TAB: 0}
+    model_search_query = {MODEL_TAB: "", TTS_TAB: "", IMAGE_TAB: ""}
     filtered_model_indices = {
         MODEL_TAB: _filter_config_model_indices(model_items, "", tts=False),
         TTS_TAB: _filter_config_model_indices(model_items, "", tts=True),
+        IMAGE_TAB: _filter_config_model_indices(model_items, "", image=True),
     }
     settings_cursor = 0
     adding_model = False
@@ -302,6 +396,9 @@ def interactive_config_menu(
 
     def _model_tab_is_tts(tab: int) -> bool:
         return tab == TTS_TAB
+
+    def _model_tab_is_image(tab: int) -> bool:
+        return tab == IMAGE_TAB
 
     def _model_page_count(tab: int | None = None) -> int:
         tab = active_tab if tab is None else tab
@@ -329,7 +426,10 @@ def interactive_config_menu(
         tab = active_tab if tab is None else tab
         current = model_cursor[tab]
         filtered_model_indices[tab] = _filter_config_model_indices(
-            model_items, model_search_query[tab], tts=_model_tab_is_tts(tab)
+            model_items,
+            model_search_query[tab],
+            tts=_model_tab_is_tts(tab),
+            image=_model_tab_is_image(tab),
         )
         indices = filtered_model_indices[tab]
         if not indices:
@@ -376,7 +476,12 @@ def interactive_config_menu(
 
         if _is_model_tab():
             if adding_model:
-                label = "add TTS model" if adding_model_tab == TTS_TAB else "add model"
+                if adding_model_tab == TTS_TAB:
+                    label = "add TTS model"
+                elif adding_model_tab == IMAGE_TAB:
+                    label = "add image model"
+                else:
+                    label = "add model"
                 add_label = f"{S.HGRN}{label}{S.RST}"
                 add_query = add_model_buffer or f"{S.DIM}provider/model-id{S.RST}"
                 buf.append(_box_row(f"{add_label}: {add_query}", w) + "\033[K\n")
@@ -411,7 +516,9 @@ def interactive_config_menu(
                     buf.append(_box_row(f"{mk} [{chk}] {ns} {ids}{ps}", w) + "\033[K\n")
                 elif row == 0 and not indices:
                     message = "No TTS models match the current search."
-                    if active_tab == MODEL_TAB:
+                    if active_tab == IMAGE_TAB:
+                        message = "No image models match the current search."
+                    elif active_tab == MODEL_TAB:
                         message = "No models match the current search."
                     buf.append(_box_row(f"{S.DIM}{message}{S.RST}", w) + "\033[K\n")
                 else:
@@ -474,12 +581,12 @@ def interactive_config_menu(
         buf.append(_box_row("", w) + "\033[K\n")
 
         if _is_model_tab():
-            is_tts_tab = active_tab == TTS_TAB
-            tab_total = sum(1 for it in model_items if bool(it.get("is_tts")) is is_tts_tab)
+            category = _model_tab_category(active_tab)
+            tab_total = sum(1 for it in model_items if it.get("category") == category)
             sel = sum(
                 1
                 for it in model_items
-                if it["selected"] and bool(it.get("is_tts")) is is_tts_tab
+                if it["selected"] and it.get("category") == category
             )
             pcount = _model_page_count()
             status = (
@@ -499,6 +606,10 @@ def interactive_config_menu(
                 "tts_voice": "alloy",
                 "tts_format": "mp3",
                 "tts_speed": 1.0,
+                "image_settings": "provider defaults",
+                "image_aspect_ratio": "1:1",
+                "image_size": "1K",
+                "image_model_ids": [],
             }
             changed = any(
                 it["value"] != current_config.get(it["key"], defaults.get(it["key"]))
@@ -554,7 +665,7 @@ def interactive_config_menu(
                     mid = add_model_buffer.strip()
                     if mid and mid not in seen_ids:
                         short = _unique_short_name(mid, existing_names)
-                        is_tts = is_tts_model(mid)
+                        category = _model_tab_category(adding_model_tab)
                         existing_names.add(short)
                         seen_ids.add(mid)
                         model_items.append(
@@ -563,14 +674,17 @@ def interactive_config_menu(
                                 "id": mid,
                                 "selected": True,
                                 "pricing": "",
-                                "is_tts": is_tts,
+                                "category": category,
+                                "is_tts": category == "tts",
+                                "is_image": category == "image",
                             }
                         )
                         _nat_short_w = max(_nat_short_w, len(short) + 2)
                         _nat_id_w = max(_nat_id_w, len(mid) + 2)
-                        added_tab = TTS_TAB if is_tts else MODEL_TAB
+                        added_tab = adding_model_tab
                         _refresh_model_filter(MODEL_TAB, preserve_current=True)
                         _refresh_model_filter(TTS_TAB, preserve_current=True)
+                        _refresh_model_filter(IMAGE_TAB, preserve_current=True)
                         model_cursor[added_tab] = len(model_items) - 1
                         _sync_model_page_from_cursor(added_tab)
                         active_tab = added_tab
@@ -635,12 +749,14 @@ def interactive_config_menu(
             elif key in ("enter", "tab"):
                 break
             elif key == "ctrl-a" and _is_model_tab():
+                category = _model_tab_category(active_tab)
                 for it in model_items:
-                    if bool(it.get("is_tts")) is (active_tab == TTS_TAB):
+                    if it.get("category") == category:
                         it["selected"] = True
             elif key == "ctrl-n" and _is_model_tab():
+                category = _model_tab_category(active_tab)
                 for it in model_items:
-                    if bool(it.get("is_tts")) is (active_tab == TTS_TAB):
+                    if it.get("category") == category:
                         it["selected"] = False
             elif key in ("[", "]") and _is_model_tab() and filtered_model_indices[active_tab]:
                 pcount = _model_page_count()
@@ -679,6 +795,9 @@ def interactive_config_menu(
     new_config = dict(current_config)
     for item in settings_items:
         new_config[item["key"]] = item["value"]
+    new_config["image_model_ids"] = [
+        it["id"] for it in model_items if it["selected"] and it.get("category") == "image"
+    ]
 
     print()
     return selected, new_config

--- a/wavebench/tui/progress/tracker.py
+++ b/wavebench/tui/progress/tracker.py
@@ -317,7 +317,7 @@ class ProgressTracker:
 
     @staticmethod
     def _format_bytes(num_bytes: float) -> str:
-        """Format byte counts for TTS audio progress."""
+        """Format byte counts for generated binary outputs."""
         if num_bytes < 1024:
             return f"{int(num_bytes)} B"
         if num_bytes < 1024 * 1024:
@@ -338,6 +338,8 @@ class ProgressTracker:
         """Boxes based on token progress: each box = 20% of avg tokens."""
         if self._progress_unit == "bytes":
             pct = min(chars / (64 * 1024), 1.0)
+        elif self._progress_unit == "images":
+            pct = min(chars, 1.0)
         else:
             avg = self._avg_tokens.get(model_name, self.DEFAULT_AVG_TOKENS)
             est_tokens = chars / 4
@@ -405,9 +407,13 @@ class ProgressTracker:
             usage = info.get("usage", {})
             tokens = usage.get("total_tokens")
             audio_bytes = usage.get("audio_bytes")
+            image_count = usage.get("image_count")
             fname = info.get("file", "")
             if audio_bytes:
                 usage_part = f"  {S.DIM}{self._format_bytes(audio_bytes)}{S.RST}"
+            elif image_count:
+                label = "image" if image_count == 1 else "images"
+                usage_part = f"  {S.DIM}{image_count} {label}{S.RST}"
             elif tokens:
                 usage_part = f"  {S.DIM}{tokens:,} tk{S.RST}"
             else:


### PR DESCRIPTION
Linear issue: https://linear.app/corbins-workspace/issue/COR-6/add-first-class-text-to-image-benchmarking-mode

Branch: `corbincaldwell/cor-6-add-first-class-text-to-image-benchmarking-mode`
Base: `main`

Created by Symphony after the Linear issue was moved to Merging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new end-to-end execution path (CLI, model selection, API calls, runner output writing) for image generation, which touches orchestration and catalog filtering and could impact model selection and run output behavior.
> 
> **Overview**
> Adds a first-class **Image** benchmarking mode end-to-end: new `ImageMode` that extracts base64 image data URLs, writes one-or-more image files per model, and generates a themed `gallery.html` viewer (with optional auto-open after the run).
> 
> Extends CLI, orchestrator, progress UI, and config menu/model catalog handling to support image-specific settings (aspect ratio/size), an Image tab with dedicated default model mapping, image-aware model classification/modalities, and a new non-streaming `call_image_generation()` API path; image runs also skip history/analytics recording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a1c4cedbb5e401ceed07995b198d1612506cc20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->