### PR TITLE
COR-9: TODO: Split prompt history by model category

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ benchmarkResults/
 .benchmark_config.json
 .benchmark_models.json
 .benchmark_query_history
+.benchmark_query_history.*
 build/
 *.egg-info/
 .pi/

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ wavebench
 python -m wavebench
 ```
 
-Interactive startup shows a **Code / Text / TTS** mode selector, a summary of active models, and a prompt input with readline-style history. Type `c` at the mode prompt to open the configuration menu.
+Interactive startup shows a **Code / Text / TTS / Image** mode selector, a summary of active models, and a prompt input with mode-specific readline-style history. Type `c` at the mode prompt to open the configuration menu.
 
 ### CLI Flags
 
@@ -155,7 +155,9 @@ These are created in the current working directory and are gitignored:
 | `.benchmark_models.json` | Currently selected `{short_name: openrouter_id}` model mapping |
 | `.benchmark_config.json` | Settings such as theme, reasoning effort, analytics sort, directory naming, auto-open, auto-install, and TTS voice/format/speed |
 | `.benchmark_history.json` | Lifetime run history for analytics |
-| `.benchmark_query_history` | Readline-style prompt history |
+| `.benchmark_query_history.<mode>` | Mode-specific readline-style prompt history for `code`, `text`, `tts`, and `image` prompts |
+
+If a legacy `.benchmark_query_history` file exists, Code mode reads it until `.benchmark_query_history.code` is created on the first new Code prompt.
 
 Because state paths are based on `os.getcwd()`, running WaveBench from different directories creates separate project-local state. TTS mode automatically uses selected TTS-capable models, falling back to the bundled TTS defaults when none are selected.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -223,9 +223,13 @@ WaveBench stores local state in the current working directory:
 | `.benchmark_models.json` | selected `{short_name: openrouter_id}` mapping; TTS mode filters this to TTS-capable IDs and falls back to bundled TTS defaults if none are selected |
 | `.benchmark_config.json` | `reasoning_effort`, `analytics_sort`, `theme`, `directory_naming`, `auto_open`, `auto_install`, `tts_voice`, `tts_format`, `tts_speed` |
 | `.benchmark_history.json` | `{version: 1, runs: [...]}` analytics history |
-| `.benchmark_query_history` | prompt-entry history for the interactive editor |
+| `.benchmark_query_history.<mode>` | mode-specific prompt-entry history for the interactive editor (`code`, `text`, `tts`, `image`) |
 
-The path helpers in `storage.py` call `os.getcwd()` at use time. This keeps
+For backward compatibility, Code mode reads a legacy `.benchmark_query_history`
+file until `.benchmark_query_history.code` is created on the first new Code
+prompt.
+
+Persistent-state path helpers call `os.getcwd()` at use time. This keeps
 tests easy to isolate with `monkeypatch.chdir(tmp_path)` and gives each project
 directory its own WaveBench state, but it also means running from a different
 directory uses different settings/history.

--- a/tests/unit/test_main_cli_tts.py
+++ b/tests/unit/test_main_cli_tts.py
@@ -44,8 +44,16 @@ def test_mode_tts_flag_skips_interactive_mode_selector(monkeypatch) -> None:
     monkeypatch.setattr(main_mod, "load_models", lambda: None)
     monkeypatch.setattr(main_mod, "load_config", _default_config)
     monkeypatch.setattr(main_mod, "apply_theme", lambda _theme: None)
-    monkeypatch.setattr(main_mod, "_load_query_history", lambda: None)
-    monkeypatch.setattr(main_mod, "_save_query_history", lambda _query: None)
+    monkeypatch.setattr(
+        main_mod,
+        "_load_query_history",
+        lambda mode_name: seen.__setitem__("load_history_mode", mode_name),
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "_save_query_history",
+        lambda _query, mode_name: seen.__setitem__("save_history_mode", mode_name),
+    )
     monkeypatch.setattr(main_mod, "_read_key_timeout", fail_if_mode_selector_reads_key)
     monkeypatch.setattr(
         main_mod,
@@ -57,6 +65,8 @@ def test_mode_tts_flag_skips_interactive_mode_selector(monkeypatch) -> None:
     main_mod.main()
 
     assert seen == {
+        "load_history_mode": "tts",
+        "save_history_mode": "tts",
         "prompt": "Hello from WaveBench",
         "mode": "tts",
         "text": False,

--- a/tests/unit/test_main_query_history.py
+++ b/tests/unit/test_main_query_history.py
@@ -1,0 +1,139 @@
+"""Unit coverage for interactive prompt history persistence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class FakeReadline:
+    def __init__(self) -> None:
+        self.items: list[str] = []
+        self.read_paths: list[Path] = []
+        self.write_paths: list[Path] = []
+        self.history_length: int | None = None
+
+    def clear_history(self) -> None:
+        self.items = []
+
+    def read_history_file(self, path: str) -> None:
+        history_path = Path(path)
+        self.read_paths.append(history_path)
+        self.items = history_path.read_text(encoding="utf-8").splitlines()
+
+    def set_history_length(self, length: int) -> None:
+        self.history_length = length
+
+    def add_history(self, query: str) -> None:
+        self.items.append(query)
+
+    def write_history_file(self, path: str) -> None:
+        history_path = Path(path)
+        self.write_paths.append(history_path)
+        text = "\n".join(self.items)
+        if text:
+            text += "\n"
+        history_path.write_text(text, encoding="utf-8")
+
+
+def test_query_history_path_is_mode_specific_and_cwd_scoped(tmp_state_dir: Path) -> None:
+    from wavebench import __main__ as main_mod
+
+    assert Path(main_mod._query_history_path("code")) == (
+        tmp_state_dir / ".benchmark_query_history.code"
+    )
+    assert Path(main_mod._query_history_path("image")) == (
+        tmp_state_dir / ".benchmark_query_history.image"
+    )
+
+
+def test_load_query_history_uses_selected_mode_and_legacy_code_fallback(
+    tmp_state_dir: Path, monkeypatch
+) -> None:
+    from wavebench import __main__ as main_mod
+
+    fake = FakeReadline()
+    monkeypatch.setattr(main_mod, "readline", fake)
+
+    (tmp_state_dir / ".benchmark_query_history").write_text("legacy code\n", encoding="utf-8")
+    (tmp_state_dir / ".benchmark_query_history.image").write_text(
+        "draw a wave\n", encoding="utf-8"
+    )
+
+    main_mod._load_query_history("image")
+    assert fake.items == ["draw a wave"]
+    assert fake.read_paths[-1] == tmp_state_dir / ".benchmark_query_history.image"
+    assert fake.history_length == 500
+
+    main_mod._load_query_history("text")
+    assert fake.items == []
+
+    main_mod._load_query_history("code")
+    assert fake.items == ["legacy code"]
+    assert fake.read_paths[-1] == tmp_state_dir / ".benchmark_query_history"
+
+    (tmp_state_dir / ".benchmark_query_history.code").write_text(
+        "specific code\n", encoding="utf-8"
+    )
+    main_mod._load_query_history("code")
+    assert fake.items == ["specific code"]
+    assert fake.read_paths[-1] == tmp_state_dir / ".benchmark_query_history.code"
+
+
+def test_save_query_history_writes_only_selected_mode_file(
+    tmp_state_dir: Path, monkeypatch
+) -> None:
+    from wavebench import __main__ as main_mod
+
+    fake = FakeReadline()
+    monkeypatch.setattr(main_mod, "readline", fake)
+
+    (tmp_state_dir / ".benchmark_query_history.image").write_text(
+        "old image\n", encoding="utf-8"
+    )
+    main_mod._load_query_history("image")
+    main_mod._save_query_history("new image", "image")
+
+    assert (tmp_state_dir / ".benchmark_query_history.image").read_text(
+        encoding="utf-8"
+    ) == "old image\nnew image\n"
+    assert not (tmp_state_dir / ".benchmark_query_history.code").exists()
+
+    main_mod._load_query_history("code")
+    main_mod._save_query_history("new code", "code")
+
+    assert (tmp_state_dir / ".benchmark_query_history.code").read_text(
+        encoding="utf-8"
+    ) == "new code\n"
+    assert (tmp_state_dir / ".benchmark_query_history.image").read_text(
+        encoding="utf-8"
+    ) == "old image\nnew image\n"
+
+
+def test_save_query_history_migrates_legacy_code_history_on_first_code_use(
+    tmp_state_dir: Path, monkeypatch
+) -> None:
+    from wavebench import __main__ as main_mod
+
+    fake = FakeReadline()
+    monkeypatch.setattr(main_mod, "readline", fake)
+    legacy_path = tmp_state_dir / ".benchmark_query_history"
+    legacy_path.write_text("legacy code\n", encoding="utf-8")
+
+    main_mod._load_query_history("code")
+    main_mod._save_query_history("new code", "code")
+
+    assert (tmp_state_dir / ".benchmark_query_history.code").read_text(
+        encoding="utf-8"
+    ) == "legacy code\nnew code\n"
+    assert legacy_path.read_text(encoding="utf-8") == "legacy code\n"
+
+
+def test_query_history_helpers_noop_without_readline(tmp_state_dir: Path, monkeypatch) -> None:
+    from wavebench import __main__ as main_mod
+
+    monkeypatch.setattr(main_mod, "readline", None)
+
+    main_mod._load_query_history("image")
+    main_mod._save_query_history("draw a wave", "image")
+
+    assert not (tmp_state_dir / ".benchmark_query_history.image").exists()

--- a/wavebench/__main__.py
+++ b/wavebench/__main__.py
@@ -58,14 +58,23 @@ from wavebench.tui.styles import (
 QUERY_HISTORY_FILE = ".benchmark_query_history"
 
 
-def _query_history_path() -> str:
-    return os.path.join(os.getcwd(), QUERY_HISTORY_FILE)
+def _query_history_path(mode_name: str = "code") -> str:
+    return os.path.join(os.getcwd(), f"{QUERY_HISTORY_FILE}.{mode_name}")
 
 
-def _load_query_history() -> None:
+def _query_history_load_path(mode_name: str = "code") -> str:
+    path = _query_history_path(mode_name)
+    if mode_name == "code" and not os.path.exists(path):
+        legacy_path = os.path.join(os.getcwd(), QUERY_HISTORY_FILE)
+        if os.path.exists(legacy_path):
+            return legacy_path
+    return path
+
+
+def _load_query_history(mode_name: str = "code") -> None:
     if readline is None:
         return
-    path = _query_history_path()
+    path = _query_history_load_path(mode_name)
     try:
         readline.clear_history()
     except Exception:
@@ -81,12 +90,12 @@ def _load_query_history() -> None:
         pass
 
 
-def _save_query_history(query: str) -> None:
+def _save_query_history(query: str, mode_name: str = "code") -> None:
     if readline is None or not query:
         return
     try:
         readline.add_history(query)
-        readline.write_history_file(_query_history_path())
+        readline.write_history_file(_query_history_path(mode_name))
     except Exception:
         pass
 
@@ -405,7 +414,7 @@ def main() -> None:
 
             # ── Prompt input ──────────────────────────────────────────
             try:
-                _load_query_history()
+                _load_query_history(mode_name)
                 history_entries: list[str] = []
                 if readline:
                     for i in range(readline.get_current_history_length()):
@@ -421,7 +430,7 @@ def main() -> None:
                 if not user_prompt.strip():
                     _refresh_header()
                     continue
-                _save_query_history(user_prompt)
+                _save_query_history(user_prompt, mode_name)
             except _TabEscape:
                 sys.stdout.write(f"\x1b[{_PROMPT_ROW + 1};1H\x1b[J")
                 sys.stdout.flush()


### PR DESCRIPTION
Linear issue: https://linear.app/corbins-workspace/issue/COR-9/todo-split-prompt-history-by-model-category

Branch: `corbincaldwell/cor-9-todo-split-prompt-history-by-model-category`
Base: `main`

Created by Symphony after the Linear issue was moved to Merging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to local readline history persistence and docs/tests, with a backward-compatible fallback for the legacy history file.
> 
> **Overview**
> Interactive prompt history is now persisted per mode (e.g. `.benchmark_query_history.code`, `.text`, `.tts`, `.image`) instead of a single shared file, and the CLI loads/saves history based on the active mode.
> 
> Adds a backward-compatible Code-mode fallback to read the legacy `.benchmark_query_history` until a new `.benchmark_query_history.code` is written, updates docs/`.gitignore` accordingly, and expands unit coverage to validate mode-specific history behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95bc4f3d7ad868c088e98aed117dd71dfba8339d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->