### PR TITLE
Stop the default pytest run spending real OpenRouter credits

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,7 +8,9 @@ to review.
 
 - Python 3.10+
 - An [OpenRouter API key](https://openrouter.ai/keys) only if you want to run
-  real benchmarks. The test suite never calls OpenRouter.
+  real benchmarks. The default test suite never calls OpenRouter; the only
+  live test is marked `slow`, which is deselected by default and only runs
+  when you explicitly opt in with `python -m pytest -m slow`.
 
 ## Local setup
 
@@ -42,8 +44,19 @@ The suite is intentionally fast; it currently runs in well under a second in
 the project venv. If your shell's default Python does not have the dev extras
 installed, use `.venv/bin/python -m pytest ...`.
 
-If you're writing a slow test, mark it with `@pytest.mark.slow` and run it
-with `python -m pytest -m slow` when needed.
+Tests marked `@pytest.mark.slow` are **deselected by default** (via `addopts`
+in `pyproject.toml`). This marker gates live tests that make real OpenRouter
+calls and spend API credits — currently
+`tests/integration/test_directory_naming_live.py`. To run them intentionally:
+
+```bash
+python -m pytest -m slow                # only the slow/live tests
+```
+
+These require `OPENROUTER_API_KEY` in the environment or `.env` and will
+skip without it. If you're writing a new test that is slow or hits the
+network, mark it with `@pytest.mark.slow` so the default suite stays fast,
+free, and offline.
 
 ## Style & linting
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,7 +239,7 @@ directory uses different settings/history.
 | Tier | Location | Purpose |
 |---|---|---|
 | Unit | `tests/unit/` | Pure functions, mode behavior, storage round-trips, public imports |
-| Integration | `tests/integration/` | Mocked OpenRouter/SSE behavior through real API-client code paths |
+| Integration | `tests/integration/` | Mocked OpenRouter/SSE behavior through real API-client code paths. One exception: `test_directory_naming_live.py` makes a real OpenRouter call; it is marked `slow`, deselected by default, and runs only via `pytest -m slow` |
 | Characterization | `tests/characterization/` | Contract tests around refactor-sensitive seams such as core, menus, and progress |
 
 Fixtures in `tests/conftest.py`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ ignore = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
-addopts = "--strict-markers -ra"
+addopts = "--strict-markers -ra -m 'not slow'"
 markers = [
-    "slow: marks tests that take several seconds (deselect with -m 'not slow')",
+    "slow: live/expensive tests (real OpenRouter calls); deselected by default, opt in with -m slow",
 ]

--- a/tests/integration/test_directory_naming_live.py
+++ b/tests/integration/test_directory_naming_live.py
@@ -1,7 +1,10 @@
 """Live integration test for prompt-derived directory naming.
 
-This test intentionally calls OpenRouter. It is skipped unless
-``OPENROUTER_API_KEY`` is available in the environment or local ``.env`` file.
+This test intentionally calls OpenRouter and spends real API credits. It is
+marked ``slow`` and therefore deselected by default (see ``addopts`` in
+``pyproject.toml``); run it explicitly with ``python -m pytest -m slow``.
+Even then it is skipped unless ``OPENROUTER_API_KEY`` is available in the
+environment or local ``.env`` file.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Fixes #25.

## Problem

`test_get_directory_name_live_openrouter_call_succeeds` makes a real OpenRouter API call, and `addopts = "--strict-markers -ra"` did not deselect its `slow` marker — so the documented `python -m pytest` ran it. Since `load_api_key()` falls back to the repo-root `.env`, any developer with a key configured silently spent credits and got a network-flaky suite on every full run, while `docs/CONTRIBUTING.md` claimed "The test suite never calls OpenRouter."

## Changes

- **`pyproject.toml`** — `addopts` now includes `-m 'not slow'`, so slow/live tests are deselected by default. An explicit `python -m pytest -m slow` still overrides it (last `-m` wins), preserving the intentional opt-in. Marker description updated to say what `slow` actually gates.
- **`docs/CONTRIBUTING.md`** — corrected the "never calls OpenRouter" claim (now: the *default* suite never does; the live test is opt-in), and documented the `-m slow` opt-in, its credit cost, and its key requirement.
- **`docs/architecture.md`** — the testing-tier table no longer claims `tests/integration/` is fully mocked; it names the one live exception and how it is gated.
- **`tests/integration/test_directory_naming_live.py`** — docstring now states the default deselection and the opt-in command.

## Verification

```
$ python -m pytest
410 passed, 1 deselected in 2.31s

$ python -m pytest -m slow --collect-only -q
tests/integration/test_directory_naming_live.py::test_get_directory_name_live_openrouter_call_succeeds
1/411 tests collected (410 deselected)
```

Run with a real `OPENROUTER_API_KEY` present in the environment: the default suite made no network call.

This is also the prerequisite for the CI issue (#17) — CI can now run the suite without spending credits.
