### PR TITLE
Add CI: run ruff and the test suite on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e '.[dev]'
+      # Keep this ruff version in lockstep with the rev pinned in
+      # .pre-commit-config.yaml, so CI and the client-side hook agree.
+      - run: pip install 'ruff==0.15.11'
+      - run: ruff check .
+      - run: ruff format --check .
+      # "not slow" keeps the live OpenRouter test (real API credits) out of CI.
+      - run: python -m pytest -m "not slow"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 repos:
+  # Keep this rev in lockstep with the ruff version installed in
+  # .github/workflows/ci.yml, so CI and the client-side hook agree.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.5
+    rev: v0.15.11
     hooks:
       - id: ruff
         name: ruff-check

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -35,6 +35,7 @@ hooks:
     python3 -m venv .venv
     . .venv/bin/activate
     pip install -e '.[dev]'
+    pre-commit install
   before_run: |
     git status --short --branch
   after_run: |

--- a/symphony/__main__.py
+++ b/symphony/__main__.py
@@ -58,7 +58,9 @@ def main(argv: list[str] | None = None) -> int:
 async def _async_main(args: argparse.Namespace) -> None:
     workflow_path = select_workflow_path(args.workflow)
     if args.workflow and not Path(args.workflow).exists():
-        raise SymphonyError("missing_workflow_file", f"explicit workflow path does not exist: {args.workflow}")
+        raise SymphonyError(
+            "missing_workflow_file", f"explicit workflow path does not exist: {args.workflow}"
+        )
     load_dotenv(workflow_path.parent / ".env")
     workflow = load_workflow(workflow_path)
     config = resolve_config(workflow)

--- a/symphony/agent.py
+++ b/symphony/agent.py
@@ -95,7 +95,9 @@ class PiRpcClient:
         await self._send(message)
         response = await self._read_response(request_id, "prompt", self.config.read_timeout_ms)
         if not response.get("success"):
-            return RunResult(False, "response_error", str(response.get("error") or "prompt rejected"))
+            return RunResult(
+                False, "response_error", str(response.get("error") or "prompt rejected")
+            )
         return await self._read_agent_completion(issue)
 
     async def stop(self) -> None:
@@ -247,7 +249,9 @@ class PiRpcClient:
             line = await process.stderr.readline()
             if not line:
                 return
-            _LOG.debug("pi_stderr pid=%s message=%r", process.pid, line.decode(errors="replace")[:500])
+            _LOG.debug(
+                "pi_stderr pid=%s message=%r", process.pid, line.decode(errors="replace")[:500]
+            )
 
     def _request_id(self) -> int:
         value = self._next_id
@@ -258,7 +262,9 @@ class PiRpcClient:
         try:
             workspace.relative_to(self.workspace_root)
         except ValueError as exc:
-            raise AgentError("invalid_workspace_cwd", f"cwd escapes workspace root: {workspace}") from exc
+            raise AgentError(
+                "invalid_workspace_cwd", f"cwd escapes workspace root: {workspace}"
+            ) from exc
 
 
 class AgentRunner:

--- a/symphony/config.py
+++ b/symphony/config.py
@@ -114,9 +114,7 @@ def resolve_config(
         api_key=api_key,
         project_slug=project_slug,
         active_states=_string_list(tracker_raw.get("active_states"), _DEFAULT_ACTIVE_STATES),
-        terminal_states=_string_list(
-            tracker_raw.get("terminal_states"), _DEFAULT_TERMINAL_STATES
-        ),
+        terminal_states=_string_list(tracker_raw.get("terminal_states"), _DEFAULT_TERMINAL_STATES),
         working_state=_optional_str(tracker_raw.get("working_state")) or _DEFAULT_WORKING_STATE,
         review_state=_optional_str(tracker_raw.get("review_state")) or _DEFAULT_REVIEW_STATE,
         merging_state=_optional_str(tracker_raw.get("merging_state")) or _DEFAULT_MERGING_STATE,
@@ -158,9 +156,7 @@ def resolve_config(
         ingest_linear_images=_bool_value(
             pi_raw.get("ingest_linear_images"), False, "pi.ingest_linear_images"
         ),
-        max_linear_images=_positive_int(
-            pi_raw.get("max_linear_images"), 6, "pi.max_linear_images"
-        ),
+        max_linear_images=_positive_int(pi_raw.get("max_linear_images"), 6, "pi.max_linear_images"),
         max_linear_image_bytes=_positive_int(
             pi_raw.get("max_linear_image_bytes"), 8_000_000, "pi.max_linear_image_bytes"
         ),

--- a/symphony/linear.py
+++ b/symphony/linear.py
@@ -204,7 +204,8 @@ class LinearClient:
             after = page_info.get("endCursor")
             if not after:
                 raise TrackerError(
-                    "linear_missing_end_cursor", "Linear pageInfo.hasNextPage was true without endCursor"
+                    "linear_missing_end_cursor",
+                    "Linear pageInfo.hasNextPage was true without endCursor",
                 )
         return issues
 
@@ -385,7 +386,9 @@ class LinearClient:
         try:
             team_id = payload["data"]["issue"]["team"]["id"]
         except (KeyError, TypeError) as exc:
-            raise TrackerError("linear_unknown_payload", "Linear payload missing issue.team.id") from exc
+            raise TrackerError(
+                "linear_unknown_payload", "Linear payload missing issue.team.id"
+            ) from exc
         if not team_id:
             raise TrackerError("linear_unknown_payload", "Linear issue team id was empty")
         return str(team_id)
@@ -399,9 +402,10 @@ class LinearClient:
             "Content-Type": "application/json",
         }
         try:
-            async with aiohttp.ClientSession(timeout=self.timeout) as session, session.post(
-                self.config.endpoint, json=body, headers=headers
-            ) as response:
+            async with (
+                aiohttp.ClientSession(timeout=self.timeout) as session,
+                session.post(self.config.endpoint, json=body, headers=headers) as response,
+            ):
                 text = await response.text()
                 if response.status != 200:
                     raise TrackerError(
@@ -410,7 +414,9 @@ class LinearClient:
                 try:
                     payload = await response.json()
                 except Exception as exc:
-                    raise TrackerError("linear_unknown_payload", "Linear returned invalid JSON") from exc
+                    raise TrackerError(
+                        "linear_unknown_payload", "Linear returned invalid JSON"
+                    ) from exc
         except asyncio.TimeoutError as exc:
             raise TrackerError("linear_api_request", "Linear request timed out") from exc
         except aiohttp.ClientError as exc:
@@ -453,7 +459,9 @@ def _extract_issues_page(payload: dict[str, Any]) -> dict[str, Any]:
         page = payload["data"]["issues"]
         nodes = page["nodes"]
     except (KeyError, TypeError) as exc:
-        raise TrackerError("linear_unknown_payload", "Linear payload missing data.issues.nodes") from exc
+        raise TrackerError(
+            "linear_unknown_payload", "Linear payload missing data.issues.nodes"
+        ) from exc
     if not isinstance(nodes, list):
         raise TrackerError("linear_unknown_payload", "Linear data.issues.nodes was not a list")
     return page
@@ -463,7 +471,9 @@ def _mutation_success(payload: dict[str, Any], key: str) -> bool:
     try:
         success = payload["data"][key]["success"]
     except (KeyError, TypeError) as exc:
-        raise TrackerError("linear_unknown_payload", f"Linear payload missing {key}.success") from exc
+        raise TrackerError(
+            "linear_unknown_payload", f"Linear payload missing {key}.success"
+        ) from exc
     return bool(success)
 
 
@@ -481,7 +491,7 @@ def _extract_issue_image_refs(
         source = f"comment:{comment.id}" if comment.id else "comment"
         _extract_text_image_refs(comment.body, source, refs, seen)
 
-    for attachment in ((node.get("attachments") or {}).get("nodes") or []):
+    for attachment in (node.get("attachments") or {}).get("nodes") or []:
         if not isinstance(attachment, dict):
             continue
         url = attachment.get("url")
@@ -683,7 +693,7 @@ def _normalize_issue(node: dict[str, Any]) -> Issue:
     ]
     comments = _normalize_comments(node)
     blockers: list[BlockerRef] = []
-    for relation in ((node.get("inverseRelations") or {}).get("nodes") or []):
+    for relation in (node.get("inverseRelations") or {}).get("nodes") or []:
         if str(relation.get("type", "")).lower() != "blocks":
             continue
         blocker = relation.get("issue") or {}
@@ -714,17 +724,12 @@ def _normalize_issue(node: dict[str, Any]) -> Issue:
 
 def _normalize_comments(node: dict[str, Any]) -> list[IssueComment]:
     comments: list[IssueComment] = []
-    for raw_comment in ((node.get("comments") or {}).get("nodes") or []):
+    for raw_comment in (node.get("comments") or {}).get("nodes") or []:
         if not isinstance(raw_comment, dict):
             continue
         user = raw_comment.get("user") or {}
         bot_actor = raw_comment.get("botActor") or {}
-        author = (
-            user.get("displayName")
-            or user.get("name")
-            or bot_actor.get("name")
-            or None
-        )
+        author = user.get("displayName") or user.get("name") or bot_actor.get("name") or None
         comments.append(
             IssueComment(
                 id=str(raw_comment.get("id") or ""),

--- a/symphony/orchestrator.py
+++ b/symphony/orchestrator.py
@@ -274,13 +274,20 @@ class Orchestrator:
         )
 
     def schedule_retry(
-        self, issue_id: str, identifier: str, attempt: int, error: str | None, continuation: bool = False
+        self,
+        issue_id: str,
+        identifier: str,
+        attempt: int,
+        error: str | None,
+        continuation: bool = False,
     ) -> None:
         previous = self.state.retry_attempts.pop(issue_id, None)
         if previous and previous.timer_task:
             previous.timer_task.cancel()
-        delay_ms = 1000 if continuation else min(
-            10_000 * (2 ** max(attempt - 1, 0)), self.config.agent.max_retry_backoff_ms
+        delay_ms = (
+            1000
+            if continuation
+            else min(10_000 * (2 ** max(attempt - 1, 0)), self.config.agent.max_retry_backoff_ms)
         )
         due_at_ms = time.monotonic() * 1000 + delay_ms
         timer_task = asyncio.create_task(self._retry_after(issue_id, delay_ms / 1000))
@@ -333,7 +340,9 @@ class Orchestrator:
                 ),
             )
             next_attempt = (entry.retry_attempt or 0) + 1
-            self.schedule_retry(issue_id, entry.identifier, next_attempt, result.error or result.status)
+            self.schedule_retry(
+                issue_id, entry.identifier, next_attempt, result.error or result.status
+            )
 
     async def _mark_issue_started(self, issue: Issue, attempt: int | None) -> Issue:
         if not self.config.tracker.auto_transition:
@@ -523,7 +532,9 @@ class Orchestrator:
         try:
             candidates = await self.tracker.fetch_candidate_issues()
         except Exception as exc:
-            self.schedule_retry(issue_id, retry.identifier, retry.attempt + 1, f"retry poll failed: {exc}")
+            self.schedule_retry(
+                issue_id, retry.identifier, retry.attempt + 1, f"retry poll failed: {exc}"
+            )
             return
         issue = next((candidate for candidate in candidates if candidate.id == issue_id), None)
         if issue is None:
@@ -591,7 +602,13 @@ class Orchestrator:
             if name == "message_update":
                 _record_first_turn_response_text(entry, payload)
                 _record_provider_status(entry, payload)
-            if name in {"message_end", "turn_end", "agent_end", "auto_retry_start", "auto_retry_end"}:
+            if name in {
+                "message_end",
+                "turn_end",
+                "agent_end",
+                "auto_retry_start",
+                "auto_retry_end",
+            }:
                 _record_provider_status(entry, payload)
             if name == "tool_execution_start":
                 entry.tool_execution_count += 1
@@ -635,7 +652,9 @@ class Orchestrator:
             normalized_state, self.config.agent.max_concurrent_agents
         )
         running_for_state = sum(
-            1 for entry in self.state.running.values() if entry.issue.state.lower() == normalized_state
+            1
+            for entry in self.state.running.values()
+            if entry.issue.state.lower() == normalized_state
         )
         return running_for_state < limit
 
@@ -682,7 +701,8 @@ class Orchestrator:
         ]
         totals = dict(self.state.agent_totals)
         totals["seconds_running"] += sum(
-            max((now - entry.started_at).total_seconds(), 0) for entry in self.state.running.values()
+            max((now - entry.started_at).total_seconds(), 0)
+            for entry in self.state.running.values()
         )
         return {
             "generated_at": now.isoformat(),
@@ -892,7 +912,12 @@ def _truncate_status_text(text: str, limit: int = 220) -> str:
 
 def _provider_status_is_error(status: str) -> bool:
     lowered = status.lower()
-    return "stopreason=error" in lowered or "retry" in lowered or "status=4" in lowered or "status=5" in lowered
+    return (
+        "stopreason=error" in lowered
+        or "retry" in lowered
+        or "status=4" in lowered
+        or "status=5" in lowered
+    )
 
 
 def _tool_name_from_event(payload: dict[str, Any]) -> str | None:

--- a/symphony/workflow.py
+++ b/symphony/workflow.py
@@ -124,14 +124,18 @@ def _parse_yaml_subset(text: str) -> Any:
     if not any(line.strip() and not line.lstrip().startswith("#") for line in lines):
         return {}
     try:
-        value, index = _parse_yaml_block(lines, _next_content(lines, 0), _line_indent(lines[_next_content(lines, 0)]))
+        value, index = _parse_yaml_block(
+            lines, _next_content(lines, 0), _line_indent(lines[_next_content(lines, 0)])
+        )
     except WorkflowError:
         raise
     except Exception as exc:  # defensive: present parser bugs as workflow parse errors
         raise WorkflowError("workflow_parse_error", str(exc)) from exc
     trailing = _next_content(lines, index)
     if trailing < len(lines):
-        raise WorkflowError("workflow_parse_error", f"unexpected trailing YAML at line {trailing + 1}")
+        raise WorkflowError(
+            "workflow_parse_error", f"unexpected trailing YAML at line {trailing + 1}"
+        )
     return value
 
 
@@ -155,7 +159,9 @@ def _parse_yaml_map(lines: list[str], index: int, indent: int) -> tuple[dict[str
         if current_indent < indent:
             break
         if current_indent > indent:
-            raise WorkflowError("workflow_parse_error", f"unexpected indentation at line {index + 1}")
+            raise WorkflowError(
+                "workflow_parse_error", f"unexpected indentation at line {index + 1}"
+            )
         stripped = line.strip()
         if stripped.startswith("- "):
             break
@@ -185,7 +191,9 @@ def _parse_yaml_list(lines: list[str], index: int, indent: int) -> tuple[list[An
         if current_indent < indent:
             break
         if current_indent > indent:
-            raise WorkflowError("workflow_parse_error", f"unexpected list indentation at line {index + 1}")
+            raise WorkflowError(
+                "workflow_parse_error", f"unexpected list indentation at line {index + 1}"
+            )
         stripped = line.strip()
         if not stripped.startswith("- "):
             break
@@ -277,7 +285,9 @@ def _parse_scalar(value: str) -> Any:
             try:
                 return ast.literal_eval(value)
             except (SyntaxError, ValueError) as exc:
-                raise WorkflowError("workflow_parse_error", f"invalid inline object: {value}") from exc
+                raise WorkflowError(
+                    "workflow_parse_error", f"invalid inline object: {value}"
+                ) from exc
     return value
 
 
@@ -289,7 +299,12 @@ def _strip_inline_comment(value: str) -> str:
             in_single = not in_single
         elif char == '"' and not in_single:
             in_double = not in_double
-        elif char == "#" and not in_single and not in_double and (index == 0 or value[index - 1].isspace()):
+        elif (
+            char == "#"
+            and not in_single
+            and not in_double
+            and (index == 0 or value[index - 1].isspace())
+        ):
             return value[:index].rstrip()
     return value
 
@@ -363,9 +378,7 @@ def _render_tokens(
     return "".join(output)
 
 
-def _find_if_bounds(
-    tokens: list[tuple[str, str]], start: int, end: int
-) -> tuple[int | None, int]:
+def _find_if_bounds(tokens: list[tuple[str, str]], start: int, end: int) -> tuple[int | None, int]:
     depth = 0
     else_index: int | None = None
     for index in range(start + 1, end):

--- a/symphony/workspace.py
+++ b/symphony/workspace.py
@@ -80,7 +80,8 @@ class WorkspaceManager:
         created_now = False
         if path.exists() and not path.is_dir():
             raise WorkspaceError(
-                "workspace_path_not_directory", f"workspace path exists and is not a directory: {path}"
+                "workspace_path_not_directory",
+                f"workspace path exists and is not a directory: {path}",
             )
         if not path.exists():
             path.mkdir(parents=True)
@@ -154,7 +155,9 @@ class WorkspaceManager:
 
     async def _prepare_git_workspace(self, path: Path, issue: Issue, created_now: bool) -> None:
         if not self.git.repo:
-            raise WorkspaceError("missing_git_repo", "git.repo is required when git.enabled is true")
+            raise WorkspaceError(
+                "missing_git_repo", "git.repo is required when git.enabled is true"
+            )
         if not await self._is_git_repo(path):
             if not _path_empty(path):
                 raise WorkspaceError(
@@ -236,7 +239,9 @@ class WorkspaceManager:
                         fh.write("\n")
                     fh.write(f"{_META_EXCLUDE}\n")
         except OSError as exc:
-            raise WorkspaceError("git_exclude_failed", f"could not update {exclude}: {exc}") from exc
+            raise WorkspaceError(
+                "git_exclude_failed", f"could not update {exclude}: {exc}"
+            ) from exc
 
     async def _fetch(self, path: Path) -> None:
         last_result: _CommandResult | None = None
@@ -353,10 +358,14 @@ class WorkspaceManager:
         )
 
     async def _ahead_behind(self, path: Path) -> tuple[int, int]:
-        result = await self._git(path, "rev-list", "--left-right", "--count", f"{self._base_ref()}...HEAD")
+        result = await self._git(
+            path, "rev-list", "--left-right", "--count", f"{self._base_ref()}...HEAD"
+        )
         parts = result.stdout.strip().split()
         if len(parts) != 2:
-            raise WorkspaceError("git_rev_list_failed", f"unexpected rev-list output: {result.stdout!r}")
+            raise WorkspaceError(
+                "git_rev_list_failed", f"unexpected rev-list output: {result.stdout!r}"
+            )
         return int(parts[0]), int(parts[1])
 
     async def _create_or_find_pr(self, path: Path, issue: Issue, branch: str) -> tuple[str, bool]:
@@ -398,7 +407,9 @@ class WorkspaceManager:
         )
         url = _extract_url(created.stdout.strip())
         if not url:
-            raise WorkspaceError("gh_pr_create_failed", f"could not parse PR URL: {created.stdout!r}")
+            raise WorkspaceError(
+                "gh_pr_create_failed", f"could not parse PR URL: {created.stdout!r}"
+            )
         return url, True
 
     async def _git(self, path: Path, *args: str, check: bool = True) -> _CommandResult:
@@ -518,7 +529,11 @@ def _sanitize_branch_name(raw: str, fallback: str) -> str:
     if branch.endswith(".lock"):
         branch = branch[: -len(".lock")].rstrip(".-/")
     if not branch or branch == "@":
-        return _sanitize_branch_name(fallback, "symphony/issue") if raw != fallback else "symphony/issue"
+        return (
+            _sanitize_branch_name(fallback, "symphony/issue")
+            if raw != fallback
+            else "symphony/issue"
+        )
     return branch
 
 

--- a/tests/characterization/test_menus_contract.py
+++ b/tests/characterization/test_menus_contract.py
@@ -256,7 +256,9 @@ def test_config_menu_filters_catalog_models_into_matching_tabs() -> None:
         pricing_lookup={},
     )
 
-    normal_matches = [items[i]["id"] for i in _filter_config_model_indices(items, "claude", tts=False)]
+    normal_matches = [
+        items[i]["id"] for i in _filter_config_model_indices(items, "claude", tts=False)
+    ]
     tts_matches = [items[i]["id"] for i in _filter_config_model_indices(items, "tts", tts=True)]
     image_matches = [
         items[i]["id"] for i in _filter_config_model_indices(items, "test-image", image=True)

--- a/tests/integration/test_api_streaming.py
+++ b/tests/integration/test_api_streaming.py
@@ -309,9 +309,7 @@ async def test_image_generation_posts_non_streaming_chat_request(
                     {
                         "message": {
                             "role": "assistant",
-                            "images": [
-                                {"image_url": {"url": "data:image/png;base64,aGVsbG8="}}
-                            ],
+                            "images": [{"image_url": {"url": "data:image/png;base64,aGVsbG8="}}],
                         }
                     }
                 ],

--- a/tests/unit/test_main_query_history.py
+++ b/tests/unit/test_main_query_history.py
@@ -55,9 +55,7 @@ def test_load_query_history_uses_selected_mode_and_legacy_code_fallback(
     monkeypatch.setattr(main_mod, "readline", fake)
 
     (tmp_state_dir / ".benchmark_query_history").write_text("legacy code\n", encoding="utf-8")
-    (tmp_state_dir / ".benchmark_query_history.image").write_text(
-        "draw a wave\n", encoding="utf-8"
-    )
+    (tmp_state_dir / ".benchmark_query_history.image").write_text("draw a wave\n", encoding="utf-8")
 
     main_mod._load_query_history("image")
     assert fake.items == ["draw a wave"]
@@ -87,9 +85,7 @@ def test_save_query_history_writes_only_selected_mode_file(
     fake = FakeReadline()
     monkeypatch.setattr(main_mod, "readline", fake)
 
-    (tmp_state_dir / ".benchmark_query_history.image").write_text(
-        "old image\n", encoding="utf-8"
-    )
+    (tmp_state_dir / ".benchmark_query_history.image").write_text("old image\n", encoding="utf-8")
     main_mod._load_query_history("image")
     main_mod._save_query_history("new image", "image")
 

--- a/tests/unit/test_models_scoring.py
+++ b/tests/unit/test_models_scoring.py
@@ -285,7 +285,10 @@ def test_tts_response_format_for_model_preserves_explicit_format() -> None:
 
 def test_tts_voice_for_model_preserves_explicit_voice() -> None:
     assert tts_voice_for_model("google/gemini-3.1-flash-tts-preview", "Puck") == "Puck"
-    assert tts_voice_for_model("mistralai/voxtral-mini-tts-2603", "gb_oliver_neutral") == "gb_oliver_neutral"
+    assert (
+        tts_voice_for_model("mistralai/voxtral-mini-tts-2603", "gb_oliver_neutral")
+        == "gb_oliver_neutral"
+    )
     assert tts_voice_for_model("openai/gpt-4o-mini-tts-2025-12-15", "nova") == "nova"
 
 

--- a/tests/unit/test_orchestrator_tts.py
+++ b/tests/unit/test_orchestrator_tts.py
@@ -106,4 +106,6 @@ async def test_main_async_tts_filters_selected_models_to_tts(
     )
 
     assert seen == [("tts", "voiceModel", "openai/gpt-4o-mini-tts-2025-12-15", None, "off")]
-    assert (tmp_state_dir / "benchmarkResults" / "tts_outputs" / "voiceModel.pcm").read_bytes() == b"audio"
+    assert (
+        tmp_state_dir / "benchmarkResults" / "tts_outputs" / "voiceModel.pcm"
+    ).read_bytes() == b"audio"

--- a/tests/unit/test_progress_wave.py
+++ b/tests/unit/test_progress_wave.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from itertools import pairwise
 from statistics import fmean, median
 from types import SimpleNamespace
 
@@ -333,7 +334,7 @@ def test_pulse_bar_has_no_color_seam_where_the_fill_ends(colored) -> None:
         assert len(colors) == bar_width
 
         brightness = [sum(color) for color in colors]
-        steps = [abs(b - a) for a, b in zip(brightness, brightness[1:])]
+        steps = [abs(b - a) for a, b in pairwise(brightness)]
         seam = steps[round(chars / 1000 * bar_width) - 1]
 
         assert seam <= 2 * median(steps), f"{chars=} seam={seam} steps={steps}"

--- a/tests/unit/test_progress_wave.py
+++ b/tests/unit/test_progress_wave.py
@@ -49,17 +49,13 @@ def colored(monkeypatch):
     monkeypatch.setattr(wave_mod.S, "RST", "\033[0m")
 
 
-_ANY_COLOR_OR_RESET = re.compile(
-    r"\033\[(?:38;2;(\d+);(\d+);(\d+)|38;5;(\d+)|0)m"
-)
+_ANY_COLOR_OR_RESET = re.compile(r"\033\[(?:38;2;(\d+);(\d+);(\d+)|38;5;(\d+)|0)m")
 
 
 def _rendered_colors(rendered: str) -> list[tuple[int, int, int]]:
     """Every color in a rendered wave, whichever escape form carries it."""
     return [
-        _PALETTE[int(match.group(4))]
-        if match.group(4)
-        else tuple(map(int, match.group(1, 2, 3)))
+        _PALETTE[int(match.group(4))] if match.group(4) else tuple(map(int, match.group(1, 2, 3)))
         for match in _ANY_COLOR.finditer(rendered)
     ]
 
@@ -94,9 +90,7 @@ def _cell_colors(rendered: str) -> list[tuple[int, int, int]]:
     pos = 0
     for match in _COLOR_OR_RESET.finditer(rendered):
         colors.extend(current for _ in rendered[pos : match.start()])
-        current = (
-            (0, 0, 0) if match.group(1) is None else tuple(map(int, match.groups()))
-        )
+        current = (0, 0, 0) if match.group(1) is None else tuple(map(int, match.groups()))
         pos = match.end()
     colors.extend(current for _ in rendered[pos:])
     return colors
@@ -111,9 +105,7 @@ def _hue(color: tuple[int, int, int]) -> tuple[float, ...]:
 def _hue_drift(colors: list[tuple[int, int, int]]) -> float:
     """Widest per-channel spread across a set of colors. 0.0 is one exact hue."""
     hues = [_hue(color) for color in colors if sum(color) > 25]
-    return max(
-        max(hue[i] for hue in hues) - min(hue[i] for hue in hues) for i in range(3)
-    )
+    return max(max(hue[i] for hue in hues) - min(hue[i] for hue in hues) for i in range(3))
 
 
 def test_idle_wave_layers_are_ordered_back_to_front() -> None:
@@ -355,9 +347,7 @@ def test_pulse_bar_brightness_peaks_at_the_leading_edge(colored) -> None:
 def test_bar_color_tracks_position_not_wave_height(colored) -> None:
     """Height belongs to the glyph. Keying color off the quantised height level
     banded neighbouring cells instead of blending them."""
-    colors = _cell_colors(
-        wave_mod._render_pulse_bar(1000, 1000, 30, phase=2.0, bar_width=28)
-    )
+    colors = _cell_colors(wave_mod._render_pulse_bar(1000, 1000, 30, phase=2.0, bar_width=28))
     brightness = [sum(color) for color in colors]
 
     # A full bar ramps monotonically up to its leading edge, whatever shape the
@@ -377,9 +367,7 @@ def test_rear_contours_never_outshine_the_foreground_body(colored) -> None:
         _far, middle, foreground = wave_mod._idle_wave_surfaces(
             tick, width * 2, height, intensity, phase
         )
-        rows = wave_mod.render_idle_wave(
-            tick, width, height, intensity, wave_phase=phase
-        )
+        rows = wave_mod.render_idle_wave(tick, width, height, intensity, wave_phase=phase)
 
         bodies: list[int] = []
         contours: list[int] = []
@@ -394,8 +382,7 @@ def test_rear_contours_never_outshine_the_foreground_body(colored) -> None:
             if not shades:
                 continue
             submerged = any(
-                wave_mod._surface_fill_mask(foreground, index, col)
-                for col in range(width)
+                wave_mod._surface_fill_mask(foreground, index, col) for col in range(width)
             )
             if submerged:
                 bodies.append(sum(shades[-1]))
@@ -468,8 +455,11 @@ def test_reduced_color_rows_never_go_dark(colored, palette) -> None:
         for intensity in (0.0, 0.5, 1.0):
             for index, row in enumerate(
                 wave_mod.render_idle_wave(
-                    tick=40, width=150, height=22,
-                    intensity=intensity, wave_phase=26.0,
+                    tick=40,
+                    width=150,
+                    height=22,
+                    intensity=intensity,
+                    wave_phase=26.0,
                 )
             ):
                 lit = _lit_cell_colors(row)
@@ -508,9 +498,7 @@ def test_reduced_color_costs_no_more_output_than_truecolor(colored) -> None:
 
 
 def test_truecolor_terminals_still_get_the_full_gradient(colored) -> None:
-    rows = wave_mod.render_idle_wave(
-        tick=40, width=120, height=20, intensity=0.75, wave_phase=26.0
-    )
+    rows = wave_mod.render_idle_wave(tick=40, width=120, height=20, intensity=0.75, wave_phase=26.0)
     colors = {color for row in rows for color in _rendered_colors(row)}
 
     assert not any("38;5;" in row for row in rows)

--- a/tests/unit/test_runner_image.py
+++ b/tests/unit/test_runner_image.py
@@ -88,7 +88,9 @@ async def test_run_model_writes_multiple_generated_images_with_detected_extensio
 
 
 async def test_run_model_fails_image_without_valid_data_url(tmp_path, monkeypatch) -> None:
-    async def fake_call_image_generation(*_args: Any, **_kwargs: Any) -> tuple[dict[str, Any], dict]:
+    async def fake_call_image_generation(
+        *_args: Any, **_kwargs: Any
+    ) -> tuple[dict[str, Any], dict]:
         return {"role": "assistant", "content": "plain text only"}, {}
 
     monkeypatch.setattr(runner_mod, "call_image_generation", fake_call_image_generation)

--- a/tests/unit/test_symphony_linear.py
+++ b/tests/unit/test_symphony_linear.py
@@ -30,7 +30,7 @@ def test_normalize_issue_labels_priority_and_blockers() -> None:
                     },
                     {
                         "id": "comment-new",
-                        "body": "Latest note <img alt=\"modal\" src=\"https://example.com/modal.webp\">",
+                        "body": 'Latest note <img alt="modal" src="https://example.com/modal.webp">',
                         "url": "https://linear.app/comment-new",
                         "createdAt": "2026-05-02T12:00:00.000Z",
                         "botActor": {"name": "Symphony"},
@@ -132,7 +132,9 @@ async def test_linear_graphql_tool_rejects_multiple_operations() -> None:
         TrackerConfig("linear", "https://example.invalid", "secret", "demo", [], [])
     )
 
-    result = await linear_graphql_tool(client, "query A { viewer { id } } query B { viewer { id } }")
+    result = await linear_graphql_tool(
+        client, "query A { viewer { id } } query B { viewer { id } }"
+    )
 
     assert result["success"] is False
     assert "exactly one" in result["error"]
@@ -140,7 +142,9 @@ async def test_linear_graphql_tool_rejects_multiple_operations() -> None:
 
 class WritebackClient(LinearClient):
     def __init__(self) -> None:
-        super().__init__(TrackerConfig("linear", "https://example.invalid", "secret", "demo", [], []))
+        super().__init__(
+            TrackerConfig("linear", "https://example.invalid", "secret", "demo", [], [])
+        )
         self.calls: list[dict] = []
 
     async def graphql(self, query: str, variables: dict | None = None) -> dict:
@@ -187,7 +191,9 @@ async def test_linear_writeback_helpers_create_comment_description_and_attachmen
 
     assert await client.create_comment("issue-1", "Ready for review") is True
     assert await client.update_issue_description("issue-1", "New description") is True
-    assert await client.create_attachment("issue-1", "Video", "https://example.com/video.webm") is True
+    assert (
+        await client.create_attachment("issue-1", "Video", "https://example.com/video.webm") is True
+    )
 
     assert client.calls[0]["variables"] == {
         "input": {"issueId": "issue-1", "body": "Ready for review"}

--- a/tests/unit/test_symphony_orchestrator.py
+++ b/tests/unit/test_symphony_orchestrator.py
@@ -123,7 +123,10 @@ class ProviderStatusRunner(BlockingRunner):
                     },
                 },
             )
-            on_event("agent_end", {"event": "agent_end", "payload": {"type": "agent_end", "messages": [message]}})
+            on_event(
+                "agent_end",
+                {"event": "agent_end", "payload": {"type": "agent_end", "messages": [message]}},
+            )
         return RunResult(True, "succeeded")
 
 
@@ -360,7 +363,9 @@ async def test_no_change_summary_includes_provider_status_when_response_text_mis
         await asyncio.sleep(0)
 
     assert "First response excerpt:" not in tracker.comments[1][1]
-    assert "Provider status: provider=openai, model=gpt-5.5, stopReason=stop" in tracker.comments[1][1]
+    assert (
+        "Provider status: provider=openai, model=gpt-5.5, stopReason=stop" in tracker.comments[1][1]
+    )
 
 
 def test_in_progress_issue_with_no_change_comment_is_not_dispatched_after_restart(
@@ -396,7 +401,9 @@ def test_in_progress_issue_with_no_change_comment_is_not_dispatched_after_restar
 
 
 @pytest.mark.asyncio
-async def test_merging_state_creates_pull_request_without_dispatching_worker(tmp_path: Path) -> None:
+async def test_merging_state_creates_pull_request_without_dispatching_worker(
+    tmp_path: Path,
+) -> None:
     config = make_config(tmp_path, max_concurrent=2, post_status_comments=True)
     config.git = GitConfig(
         enabled=True,

--- a/tests/unit/test_symphony_pi.py
+++ b/tests/unit/test_symphony_pi.py
@@ -26,7 +26,7 @@ from symphony.workspace import WorkspaceManager
 async def test_pi_rpc_client_runs_prompt_and_cancels_ui_dialog(tmp_path: Path) -> None:
     fake_pi = tmp_path / "fake_pi.py"
     fake_pi.write_text(
-        r'''
+        r"""
 import json
 import sys
 
@@ -73,7 +73,7 @@ for line in sys.stdin:
     elif message.get("type") == "abort":
         send({"type": "response", "command": "abort", "success": True})
         break
-''',
+""",
         encoding="utf-8",
     )
     root = tmp_path / "root"
@@ -116,7 +116,7 @@ for line in sys.stdin:
 async def test_pi_rpc_client_sends_prompt_images(tmp_path: Path) -> None:
     fake_pi = tmp_path / "fake_pi_images.py"
     fake_pi.write_text(
-        r'''
+        r"""
 import json
 import sys
 
@@ -149,7 +149,7 @@ for line in sys.stdin:
     elif message.get("type") == "abort":
         send({"type": "response", "command": "abort", "success": True})
         break
-''',
+""",
         encoding="utf-8",
     )
     root = tmp_path / "root"
@@ -178,7 +178,7 @@ for line in sys.stdin:
 async def test_agent_runner_emits_grounded_step_events(tmp_path: Path) -> None:
     fake_pi = tmp_path / "fake_pi_steps.py"
     fake_pi.write_text(
-        r'''
+        r"""
 import json
 import sys
 
@@ -210,7 +210,7 @@ for line in sys.stdin:
     elif message.get("type") == "abort":
         send({"type": "response", "command": "abort", "success": True})
         break
-''',
+""",
         encoding="utf-8",
     )
     root = tmp_path / "root"
@@ -241,7 +241,9 @@ for line in sys.stdin:
     issue = Issue(id="1", identifier="WB-1", title="Test", state="Todo")
     events: list[tuple[str, dict]] = []
 
-    result = await runner.run_attempt(issue, on_event=lambda name, payload: events.append((name, payload)))
+    result = await runner.run_attempt(
+        issue, on_event=lambda name, payload: events.append((name, payload))
+    )
 
     assert result.success is True
     steps = [payload for name, payload in events if name == "agent_step"]
@@ -287,6 +289,9 @@ def test_build_turn_prompt_appends_latest_linear_comments() -> None:
 
     assert "Issue WB-1" in prompt
     assert "Linear comments (latest first, max 12):" in prompt
-    assert "--- comment 1 | 2026-05-03T12:00:00+00:00 | Corbin | https://linear.app/comment-1 ---" in prompt
+    assert (
+        "--- comment 1 | 2026-05-03T12:00:00+00:00 | Corbin | https://linear.app/comment-1 ---"
+        in prompt
+    )
     assert "TTS fails for multiple providers." in prompt
     assert prompt.rstrip().endswith("--- end comment ---")

--- a/tests/unit/test_symphony_workspace.py
+++ b/tests/unit/test_symphony_workspace.py
@@ -84,7 +84,10 @@ async def test_git_workspace_clones_and_switches_to_issue_branch(tmp_path: Path)
 
     workspace = await manager.create_for_issue(issue)
 
-    assert _git(workspace.path, "branch", "--show-current").stdout.strip() == "symphony/wb-1-add-tts-mode"
+    assert (
+        _git(workspace.path, "branch", "--show-current").stdout.strip()
+        == "symphony/wb-1-add-tts-mode"
+    )
     assert (workspace.path / "README.md").read_text(encoding="utf-8") == "hello\n"
 
 
@@ -161,15 +164,17 @@ async def test_git_workspace_migrates_dirty_main_to_issue_branch(tmp_path: Path)
 
 
 @pytest.mark.asyncio
-async def test_create_pull_request_commits_pushes_and_uses_gh(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_create_pull_request_commits_pushes_and_uses_gh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     remote = _create_remote_repo(tmp_path)
     gh_log = tmp_path / "gh.log"
     gh = tmp_path / "gh"
     gh.write_text(
         "#!/bin/sh\n"
-        "echo \"$@\" >> \"$GH_LOG\"\n"
-        "if [ \"$1 $2\" = \"pr view\" ]; then exit 1; fi\n"
-        "if [ \"$1 $2\" = \"pr create\" ]; then echo https://github.com/example/repo/pull/7; exit 0; fi\n"
+        'echo "$@" >> "$GH_LOG"\n'
+        'if [ "$1 $2" = "pr view" ]; then exit 1; fi\n'
+        'if [ "$1 $2" = "pr create" ]; then echo https://github.com/example/repo/pull/7; exit 0; fi\n'
         "exit 2\n",
         encoding="utf-8",
     )

--- a/tests/unit/test_tts_player.py
+++ b/tests/unit/test_tts_player.py
@@ -103,7 +103,11 @@ def test_browse_tts_outputs_scrolls_when_outputs_exceed_screen(
 
     monkeypatch.setattr(tts_player.sys, "stdin", fake_stdin)
     monkeypatch.setattr(tts_player.sys, "stdout", fake_stdout)
-    monkeypatch.setattr(tts_player.shutil, "get_terminal_size", lambda fallback: tts_player.os.terminal_size((80, 8)))
+    monkeypatch.setattr(
+        tts_player.shutil,
+        "get_terminal_size",
+        lambda fallback: tts_player.os.terminal_size((80, 8)),
+    )
     monkeypatch.setattr(tts_player, "_read_key_or_resize", lambda: next(keys))
     monkeypatch.setattr(
         tts_player, "_start_audio", lambda path: (started.append(path) or True, fake_proc)
@@ -135,7 +139,9 @@ def test_start_audio_uses_native_pulse_for_gemini_pcm(tmp_path, monkeypatch) -> 
             _error,
         ):
             spec = sample_spec._obj
-            events.append(("new", (name, direction, stream_name, spec.format, spec.rate, spec.channels)))
+            events.append(
+                ("new", (name, direction, stream_name, spec.format, spec.rate, spec.channels))
+            )
             return "pulse-handle"
 
         @staticmethod
@@ -203,7 +209,9 @@ def test_start_audio_uses_native_pulse_for_decoded_mp3(tmp_path, monkeypatch) ->
             _error,
         ):
             spec = sample_spec._obj
-            events.append(("new", (name, direction, stream_name, spec.format, spec.rate, spec.channels)))
+            events.append(
+                ("new", (name, direction, stream_name, spec.format, spec.rate, spec.channels))
+            )
             return "pulse-handle"
 
         @staticmethod
@@ -294,7 +302,9 @@ def test_decode_encoded_audio_falls_back_to_sndfile_without_mpg123(monkeypatch) 
     assert calls == [("sndfile", "openai.mp3")]
 
 
-def test_start_audio_uses_native_miniaudio_fallback_for_encoded_audio(tmp_path, monkeypatch) -> None:
+def test_start_audio_uses_native_miniaudio_fallback_for_encoded_audio(
+    tmp_path, monkeypatch
+) -> None:
     mp3 = tmp_path / "openai.mp3"
     mp3.write_bytes(b"ID3audio")
     events = []

--- a/wavebench/api.py
+++ b/wavebench/api.py
@@ -1173,7 +1173,5 @@ def fetch_top_models(api_key: str, count: int = 12) -> tuple[list[dict[str, Any]
     speech_count = min(len(speech_filtered), max(0, count - image_count), 20)
     text_count = max(0, count - image_count - speech_count)
     return (
-        filtered[:text_count]
-        + speech_filtered[:speech_count]
-        + image_filtered[:image_count]
+        filtered[:text_count] + speech_filtered[:speech_count] + image_filtered[:image_count]
     ), pricing_lookup

--- a/wavebench/core/runner.py
+++ b/wavebench/core/runner.py
@@ -291,9 +291,7 @@ async def run_model(
             total_bytes = 0
             for idx, image in enumerate(images, 1):
                 suffix = "" if idx == 1 else f"_{idx}"
-                filename = get_unique_filename(
-                    output_dir, f"{model_name}{suffix}", image.extension
-                )
+                filename = get_unique_filename(output_dir, f"{model_name}{suffix}", image.extension)
                 filepath = os.path.join(output_dir, filename)
                 with open(filepath, "wb") as fh:
                     fh.write(image.data)

--- a/wavebench/modes/image.py
+++ b/wavebench/modes/image.py
@@ -267,18 +267,18 @@ def write_image_gallery(
             filename_label = html.escape(filename, quote=False)
             suffix_label = html.escape(suffix, quote=False)
             cards.append(
-                "<figure class=\"card\">"
-                f"<button class=\"preview\" type=\"button\" data-gallery-index=\"{gallery_index}\" "
-                f"aria-label=\"Open preview for {model_alt}{html.escape(suffix, quote=True)}\">"
-                f"<img src=\"{rel}\" alt=\"{model_alt}{html.escape(suffix, quote=True)}\" "
-                "loading=\"lazy\" decoding=\"async\">"
+                '<figure class="card">'
+                f'<button class="preview" type="button" data-gallery-index="{gallery_index}" '
+                f'aria-label="Open preview for {model_alt}{html.escape(suffix, quote=True)}">'
+                f'<img src="{rel}" alt="{model_alt}{html.escape(suffix, quote=True)}" '
+                'loading="lazy" decoding="async">'
                 "</button>"
                 "<figcaption>"
                 f"<strong>{model_label}{suffix_label}</strong>"
-                f"<span class=\"filename\">{filename_label}</span>"
-                "<span class=\"actions\">"
-                f"<a href=\"{rel}\" target=\"_blank\" rel=\"noopener\">Open full size</a>"
-                f"<a href=\"{rel}\" download>Download</a>"
+                f'<span class="filename">{filename_label}</span>'
+                '<span class="actions">'
+                f'<a href="{rel}" target="_blank" rel="noopener">Open full size</a>'
+                f'<a href="{rel}" download>Download</a>'
                 "</span>"
                 "</figcaption>"
                 "</figure>"

--- a/wavebench/tui/menus/config_menu.py
+++ b/wavebench/tui/menus/config_menu.py
@@ -583,11 +583,7 @@ def interactive_config_menu(
         if _is_model_tab():
             category = _model_tab_category(active_tab)
             tab_total = sum(1 for it in model_items if it.get("category") == category)
-            sel = sum(
-                1
-                for it in model_items
-                if it["selected"] and it.get("category") == category
-            )
+            sel = sum(1 for it in model_items if it["selected"] and it.get("category") == category)
             pcount = _model_page_count()
             status = (
                 f"{S.BOLD}{sel}{S.RST} of "

--- a/wavebench/tui/progress/wave.py
+++ b/wavebench/tui/progress/wave.py
@@ -159,9 +159,7 @@ def _render_pulse_bar(
         parts.append(S.RST)
 
     if empty > 0:
-        parts.append(
-            _render_pre_wave_bar(empty, tick, crest=-1, span=bar_width, offset=filled)
-        )
+        parts.append(_render_pre_wave_bar(empty, tick, crest=-1, span=bar_width, offset=filled))
 
     return "".join(parts)
 
@@ -269,10 +267,8 @@ def _idle_wave_surfaces(
 
         middle_height = (
             0.67 * math.sin(nx * 15.8 - wave_phase * 0.074 + 0.3)
-            + (0.08 + 0.08 * intensity)
-            * math.sin(nx * 28.0 - wave_phase * 0.103 + 2.0)
-            + (0.02 + 0.04 * intensity)
-            * math.sin(nx * 47.0 - wave_phase * 0.132 + 3.4)
+            + (0.08 + 0.08 * intensity) * math.sin(nx * 28.0 - wave_phase * 0.103 + 2.0)
+            + (0.02 + 0.04 * intensity) * math.sin(nx * 47.0 - wave_phase * 0.132 + 3.4)
         )
         middle_height = _shape_wave(
             middle_height,
@@ -284,12 +280,9 @@ def _idle_wave_surfaces(
 
         foreground_height = (
             0.62 * math.sin(nx * 14.0 - wave_phase * 0.107)
-            + (0.08 + 0.14 * intensity)
-            * math.sin(nx * 26.0 - wave_phase * 0.147 + 1.7)
-            + (0.02 + 0.08 * intensity)
-            * math.sin(nx * 44.0 - wave_phase * 0.187 + 3.1)
-            + (0.01 + 0.03 * intensity)
-            * math.sin(nx * 68.0 - wave_phase * 0.240 + 0.9)
+            + (0.08 + 0.14 * intensity) * math.sin(nx * 26.0 - wave_phase * 0.147 + 1.7)
+            + (0.02 + 0.08 * intensity) * math.sin(nx * 44.0 - wave_phase * 0.187 + 3.1)
+            + (0.01 + 0.03 * intensity) * math.sin(nx * 68.0 - wave_phase * 0.240 + 0.9)
         )
         foreground_height = _shape_wave(
             foreground_height,
@@ -401,12 +394,8 @@ def render_idle_wave(
         # across them, so a row is a single run of each layer's color — which is
         # what keeps the frame down to a handful of escape sequences.
         foreground_body_code = _color_code(_scale_color(active_color, row_shade))
-        middle_contour_code = _color_code(
-            _scale_color(active_color, row_shade * middle_depth)
-        )
-        far_contour_code = _color_code(
-            _scale_color(active_color, row_shade * far_depth)
-        )
+        middle_contour_code = _color_code(_scale_color(active_color, row_shade * middle_depth))
+        far_contour_code = _color_code(_scale_color(active_color, row_shade * far_depth))
         parts: list[str] = []
         current_color: str | None = None
 

--- a/wavebench/tui/styles.py
+++ b/wavebench/tui/styles.py
@@ -62,7 +62,7 @@ _RAMP_SAMPLES = 16
 
 
 def _luma(color: tuple[int, int, int]) -> float:
-    return sum(weight * value for weight, value in zip(_LUMA_WEIGHTS, color))
+    return sum(weight * value for weight, value in zip(_LUMA_WEIGHTS, color, strict=True))
 
 
 def _hue_of(color: tuple[int, int, int]) -> tuple[float, ...]:
@@ -73,7 +73,7 @@ def _hue_of(color: tuple[int, int, int]) -> tuple[float, ...]:
 def _hue_distance(a: tuple[int, int, int], b: tuple[int, int, int]) -> float:
     return sum(
         weight * abs(x - y)
-        for weight, x, y in zip(_LUMA_WEIGHTS, _hue_of(a), _hue_of(b))
+        for weight, x, y in zip(_LUMA_WEIGHTS, _hue_of(a), _hue_of(b), strict=True)
     )
 
 
@@ -125,7 +125,7 @@ def hue_ramp(color: tuple[int, int, int]) -> tuple[tuple[int, int, int], ...]:
     ceiling = (1.0, 1.0, 1.0)
     for entry in reversed(steps):  # brightest first
         ratios = _hue_of(entry)
-        if any(ratio > limit + 1e-9 for ratio, limit in zip(ratios, ceiling)):
+        if any(ratio > limit + 1e-9 for ratio, limit in zip(ratios, ceiling, strict=True)):
             continue
         kept.append(entry)
         ceiling = ratios

--- a/wavebench/tui/tts_player.py
+++ b/wavebench/tui/tts_player.py
@@ -214,7 +214,9 @@ def _decode_sndfile(filepath: str) -> _DecodedPcm | None:
             frames_read = lib.sf_readf_short(handle, buffer, chunk_frames)
             if frames_read <= 0:
                 break
-            chunks.append(ctypes.string_at(buffer, frames_read * info.channels * _RAW_PCM_SAMPLE_WIDTH))
+            chunks.append(
+                ctypes.string_at(buffer, frames_read * info.channels * _RAW_PCM_SAMPLE_WIDTH)
+            )
     except Exception:
         return None
     finally:
@@ -621,7 +623,9 @@ def browse_tts_outputs(output_dir: str, results: dict[str, Any]) -> None:
             buf.append(_box_row(row, w) + "\033[K\n")
         if len(items) > max_rows:
             end = start + len(visible_items)
-            buf.append(_box_row(f"{S.DIM}showing {start + 1}-{end} of {len(items)}{S.RST}", w) + "\033[K\n")
+            buf.append(
+                _box_row(f"{S.DIM}showing {start + 1}-{end} of {len(items)}{S.RST}", w) + "\033[K\n"
+            )
         else:
             buf.append(_box_row("", w) + "\033[K\n")
         buf.append(_box_row(status, w) + "\033[K\n")


### PR DESCRIPTION
Fixes #17.

## Problem

`.github/workflows/` had no test or lint workflow — nothing ran `pytest` or `ruff` on any push or PR, while Symphony auto-creates PRs from agent workspaces (`symphony/workspace.py`), so agent-authored code could merge with zero mechanical review. The absence was already costing: `ruff check .` failed at HEAD with 5 errors from version drift between the pre-commit pin (v0.14.5) and the venv's ruff (0.15.11), and `ruff format --check .` failed across 25 files for the same reason.

## Changes

Three commits, ordered for review:

1. **`Fix ruff B905/RUF007 errors`** — the three `wavebench/tui/styles.py` zips pair fixed 3-tuples, so they get `strict=True` to document the invariant; the successive-pair zip in `tests/unit/test_progress_wave.py` becomes `itertools.pairwise`, which resolves both B905 and RUF007 on that line.
2. **`Reformat under ruff 0.15.11`** — mechanical `ruff format .` sweep over the 25 drifted files; no behavior change. Required because the workflow runs `ruff format --check .`, which also failed at HEAD.
3. **`Run ruff and the test suite on every PR and push to main`** — adds `.github/workflows/ci.yml` per the issue's spec: checkout, Python 3.12, `pip install -e '.[dev]'`, `ruff check .`, `ruff format --check .`, `python -m pytest -m "not slow"`.

Two deliberate details:

- **CI pins `ruff==0.15.11`**, matching the bumped pre-commit rev (`v0.14.5` → `v0.15.11`), with cross-referencing comments in both files. The dev extra's floating `ruff>=0.5` is exactly how the drift happened; an unpinned CI would go red whenever a future ruff release adds rules, unrelated to the PR under test.
- **`-m "not slow"`** keeps the live OpenRouter test (real API credits) out of CI, per the issue. This works independently of #26, which additionally deselects `slow` by default for local runs.

Also adds `pre-commit install` to Symphony's `after_create` hook in `WORKFLOW.md`, so agent workspaces get the client-side gate the issue noted they were missing.

## Verification

All three CI commands pass locally at this branch:

```
$ ruff check .                     → All checks passed!
$ ruff format --check .            → 72 files already formatted
$ python -m pytest -m "not slow"   → 410 passed, 1 deselected
```

This PR is itself the first `pull_request` run of the new workflow — check the checks tab.

## Follow-up after merge

Make `test` a required status check on `main` (Settings → Branches). It can't be set before merge: the check name only becomes selectable once it has run, and requiring it now would deadlock currently-open PRs whose branches predate the workflow file.
