### PR TITLE
Stop failed generations scoring as passes or vanishing from results

### DIFF
--- a/tests/integration/test_api_streaming.py
+++ b/tests/integration/test_api_streaming.py
@@ -23,19 +23,20 @@ from aiohttp.test_utils import TestServer
 from wavebench import api as api_mod
 
 
-async def _sse_body(chunks: list[dict]) -> bytes:
+async def _sse_body(chunks: list[dict], include_done: bool = True) -> bytes:
     """Serialize a list of SSE event dicts into the on-wire byte stream."""
     out = bytearray()
     for chunk in chunks:
         out.extend(b"data: ")
         out.extend(json.dumps(chunk).encode("utf-8"))
         out.extend(b"\n\n")
-    out.extend(b"data: [DONE]\n\n")
+    if include_done:
+        out.extend(b"data: [DONE]\n\n")
     return bytes(out)
 
 
 def _make_streaming_app(
-    chunks: list[dict], status: int = 200, err_body: str = ""
+    chunks: list[dict], status: int = 200, err_body: str = "", include_done: bool = True
 ) -> web.Application:
     """Build a test app that streams *chunks* on POST to /chat/completions."""
 
@@ -44,7 +45,7 @@ def _make_streaming_app(
             return web.Response(status=status, text=err_body)
         resp = web.StreamResponse(status=200, headers={"Content-Type": "text/event-stream"})
         await resp.prepare(request)
-        body = await _sse_body(chunks)
+        body = await _sse_body(chunks, include_done)
         # Write in a few pieces to make sure the parser handles multi-chunk input.
         mid = len(body) // 2
         await resp.write(body[:mid])
@@ -192,6 +193,102 @@ async def test_streaming_http_error_raises_runtime_error(
                     prompt="hi",
                     reasoning_effort=None,
                 )
+
+
+async def test_streaming_mid_stream_error_event_raises(
+    _reset_ctx_cache: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # OpenRouter can accept the request (HTTP 200), stream part of an
+    # answer, then deliver a terminal error event with no choices at all.
+    # Returning the partial content as if complete would score a broken
+    # generation as a pass.
+    chunks = [
+        {"choices": [{"delta": {"content": "partial answer"}}]},
+        {"error": {"code": 502, "message": "Provider returned error"}},
+    ]
+    app = _make_streaming_app(chunks, include_done=False)
+
+    async with _running_server(app) as server:
+        monkeypatch.setattr(api_mod, "API_URL", str(server.make_url("")).rstrip("/"))
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(RuntimeError, match="mid-stream error"):
+                await api_mod.call_model_streaming(
+                    session,
+                    api_key="test-key",
+                    model_id="test/model",
+                    prompt="hi",
+                    reasoning_effort=None,
+                )
+
+
+async def test_streaming_eof_without_done_is_marked_incomplete(
+    _reset_ctx_cache: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # EOF with neither a finish_reason nor the [DONE] sentinel: the
+    # connection dropped mid-generation and the tail may be missing.
+    chunks = [{"choices": [{"delta": {"content": "partial"}}]}]
+    app = _make_streaming_app(chunks, include_done=False)
+
+    async with _running_server(app) as server:
+        monkeypatch.setattr(api_mod, "API_URL", str(server.make_url("")).rstrip("/"))
+        async with aiohttp.ClientSession() as session:
+            content, usage = await api_mod.call_model_streaming(
+                session,
+                api_key="test-key",
+                model_id="test/model",
+                prompt="hi",
+                reasoning_effort=None,
+            )
+
+    assert content == "partial"
+    assert usage["finish_reason"] == "incomplete"
+
+
+async def test_streaming_finish_reason_wins_over_missing_done(
+    _reset_ctx_cache: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A provider that reports finish_reason but forgets the [DONE] sentinel
+    # still delivered a complete answer — don't flag it.
+    chunks = [{"choices": [{"delta": {"content": "whole answer"}, "finish_reason": "stop"}]}]
+    app = _make_streaming_app(chunks, include_done=False)
+
+    async with _running_server(app) as server:
+        monkeypatch.setattr(api_mod, "API_URL", str(server.make_url("")).rstrip("/"))
+        async with aiohttp.ClientSession() as session:
+            _, usage = await api_mod.call_model_streaming(
+                session,
+                api_key="test-key",
+                model_id="test/model",
+                prompt="hi",
+                reasoning_effort=None,
+            )
+
+    assert usage["finish_reason"] == "stop"
+
+
+async def test_streaming_done_without_finish_reason_is_not_flagged(
+    _reset_ctx_cache: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The [DONE] sentinel alone marks a healthy end of stream.
+    chunks = [{"choices": [{"delta": {"content": "whole answer"}}]}]
+    app = _make_streaming_app(chunks)
+
+    async with _running_server(app) as server:
+        monkeypatch.setattr(api_mod, "API_URL", str(server.make_url("")).rstrip("/"))
+        async with aiohttp.ClientSession() as session:
+            _, usage = await api_mod.call_model_streaming(
+                session,
+                api_key="test-key",
+                model_id="test/model",
+                prompt="hi",
+                reasoning_effort=None,
+            )
+
+    assert "finish_reason" not in usage
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -306,6 +306,94 @@ def test_image_mode_parse_fails_without_valid_data_url() -> None:
     assert out.parse_error == "no valid base64 image data URLs"
 
 
+def _b64_url(mime: str, data: bytes) -> str:
+    return f"data:{mime};base64," + base64.b64encode(data).decode()
+
+
+def test_image_mode_rejects_truncated_containers() -> None:
+    # b64decode happily decodes any 4-char-aligned prefix of a longer
+    # payload, so a stream cut mid-image still yields bytes with valid
+    # magic; the container trailer is the only cheap completeness signal.
+    raw = {
+        "images": [
+            {"image_url": {"url": _b64_url("image/png", b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)}},
+            {"image_url": {"url": _b64_url("image/jpeg", b"\xff\xd8\xff\xe0" + b"\x00" * 16)}},
+            {"image_url": {"url": _b64_url("image/gif", b"GIF89a" + b"\x00" * 16)}},
+            {"image_url": {"url": _b64_url("image/webp", b"RIFF\x40\x00\x00\x00WEBPVP8 ")}},
+        ]
+    }
+    assert extract_image_outputs(raw) == []
+
+
+def test_image_mode_accepts_complete_containers() -> None:
+    webp_body = b"WEBPVP8 " + b"\x00" * 8
+    raw = {
+        "images": [
+            {
+                "image_url": {
+                    "url": _b64_url("image/png", b"\x89PNG\r\n\x1a\n\x00\x00IEND\xae\x42\x60\x82")
+                }
+            },
+            {"image_url": {"url": _b64_url("image/jpeg", b"\xff\xd8\xff\xe0\x00\x00\xff\xd9")}},
+            {"image_url": {"url": _b64_url("image/gif", b"GIF89a\x00\x00;")}},
+            {
+                "image_url": {
+                    "url": _b64_url(
+                        "image/webp",
+                        b"RIFF" + len(webp_body).to_bytes(4, "little") + webp_body,
+                    )
+                }
+            },
+        ]
+    }
+    images = extract_image_outputs(raw)
+    assert [image.mime_type for image in images] == [
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/webp",
+    ]
+
+
+def test_image_mode_parse_fails_on_truncated_container() -> None:
+    url = _b64_url("image/png", b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+    out = IMAGE_MODE.parse_response({"images": [{"image_url": {"url": url}}]})  # type: ignore[arg-type]
+    assert out.parse_ok is False
+    assert out.parse_error == "no valid base64 image data URLs"
+
+
+def test_image_mode_deduplicates_identical_images_across_fields() -> None:
+    # Providers often surface the same image under message.images AND echo
+    # the data URL in content; the walk must return it once, not twice.
+    url = "data:image/png;base64,aGVsbG8="
+    raw = {
+        "images": [{"image_url": {"url": url}}],
+        "content": f"Here you go: {url}",
+    }
+    images = extract_image_outputs(raw)
+    assert len(images) == 1
+    assert images[0].data == b"hello"
+
+
+def test_image_mode_decodes_hard_wrapped_base64() -> None:
+    # Some providers hard-wrap base64 with indented continuation lines.
+    encoded = base64.b64encode(b"hello world, hello world").decode()
+    wrapped = f"{encoded[:8]}\n    {encoded[8:16]}\n    {encoded[16:]}"
+    raw = {"content": f"data:image/png;base64,{wrapped}"}
+    images = extract_image_outputs(raw)
+    assert len(images) == 1
+    assert images[0].data == b"hello world, hello world"
+
+
+def test_image_mode_recovers_data_url_followed_by_prose() -> None:
+    # The whitespace-tolerant payload class swallows trailing words; the
+    # decoder must fall back to the first run rather than lose the image.
+    raw = {"content": "data:image/png;base64,aGVsbG8= Enjoy the wave"}
+    images = extract_image_outputs(raw)
+    assert len(images) == 1
+    assert images[0].data == b"hello"
+
+
 def test_image_gallery_includes_summary_actions_and_prompt_formatting(tmp_path) -> None:
     path = write_image_gallery(
         str(tmp_path),

--- a/tests/unit/test_orchestrator_backstop.py
+++ b/tests/unit/test_orchestrator_backstop.py
@@ -1,0 +1,81 @@
+"""Unit coverage for the orchestrator's vanishing-model backstop.
+
+``run_model`` records its own failures, so an exception escaping the task
+means it died before writing a result.  ``gather(return_exceptions=True)``
+used to swallow that exception silently, and the model was simply absent
+from the results box and history — neither pass nor fail.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from wavebench.core import orchestrator as orchestrator_mod
+
+
+async def test_task_that_dies_before_recording_is_backstopped_as_failed(
+    tmp_state_dir: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    async def fake_get_directory_name(*_args: Any, **_kwargs: Any) -> str:
+        return "tts_outputs"
+
+    async def fake_run_model(
+        mode,
+        session,
+        api_key,
+        name,
+        mid,
+        user_prompt,
+        default_ext,
+        output_dir_task,
+        semaphore,
+        results,
+        pad,
+        tracker,
+        reasoning_effort="high",
+        auto_open="off",
+        auto_install="off",
+    ) -> None:
+        await output_dir_task
+        raise RuntimeError("exploded before recording a result")
+
+    monkeypatch.setattr(orchestrator_mod, "get_directory_name", fake_get_directory_name)
+    monkeypatch.setattr(orchestrator_mod, "run_model", fake_run_model)
+
+    args = SimpleNamespace(
+        prompt="Say hello",
+        mode="tts",
+        text=False,
+        auto_open=None,
+        auto_install=None,
+        tts_voice=None,
+        tts_format=None,
+        tts_speed=None,
+    )
+
+    await orchestrator_mod.main_async(
+        args,
+        api_key="test-key",
+        model_mapping={"voiceModel": "openai/gpt-4o-mini-tts-2025-12-15"},
+        config={
+            "reasoning_effort": "high",
+            "analytics_sort": "runs",
+            "auto_open": "off",
+            "auto_install": "off",
+            "directory_naming": "slug",
+            "tts_voice": "nova",
+            "tts_format": "pcm",
+            "tts_speed": 1.0,
+        },
+        pricing_lookup={},
+    )
+
+    history = json.loads((tmp_state_dir / ".benchmark_history.json").read_text(encoding="utf-8"))
+    assert history["runs"][0]["models"]["voiceModel"]["status"] == "failed"
+    # The fallback results box shows the reason, not just a bare "failed".
+    assert "exploded before" in capsys.readouterr().out

--- a/tests/unit/test_orchestrator_image.py
+++ b/tests/unit/test_orchestrator_image.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -52,7 +53,7 @@ def test_resolve_image_mode_provider_defaults_do_not_send_config() -> None:
     assert mode.image_config() is None
 
 
-async def test_main_async_image_filters_models_generates_gallery_and_skips_history(
+async def test_main_async_image_filters_models_generates_gallery_and_records_history(
     tmp_state_dir: Path,
     monkeypatch,
 ) -> None:
@@ -149,7 +150,16 @@ async def test_main_async_image_filters_models_generates_gallery_and_skips_histo
     assert "imageModel.png" in gallery_html
     assert 'data-theme="plum"' in gallery_html
     assert opened == [str(gallery)]
-    assert not (tmp_state_dir / ".benchmark_history.json").exists()
+    # Image runs are first-class history entries: "Every run is recorded".
+    history_path = tmp_state_dir / ".benchmark_history.json"
+    assert history_path.exists()
+    history = json.loads(history_path.read_text(encoding="utf-8"))
+    assert len(history["runs"]) == 1
+    run = history["runs"][0]
+    assert run["prompt"] == "A neon wave"
+    assert run["models"]["imageModel"]["status"] == "success"
+    # Reasoning effort never applies to image generation, so it is not stamped.
+    assert "reasoning_effort" not in run
 
 
 async def test_main_async_image_uses_bundled_defaults_when_no_image_models_selected(

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -436,14 +436,13 @@ async def test_parse_llm_output_stage3_salvage() -> None:
     assert result["extension"] == ".py"
 
 
-async def test_parse_llm_output_stage4_fallback_prose_to_text() -> None:
-    # No JSON, no fences — treated as raw code-like text with guessed language.
+async def test_parse_llm_output_stage4_rejects_pure_prose() -> None:
+    # No JSON, no fences, and no syntactic code marker anywhere: this is
+    # prose — typically a refusal — and saving it as code would score the
+    # model a pass for declining the task.
     content = "Hello, this is just prose with no code markers."
     result = await parse_llm_output(None, None, "dummy-model", content)
-    assert result is not None
-    assert result["language"] == "text"
-    # An unknown language leaves extension empty.
-    assert result["extension"] == ""
+    assert result is None
 
 
 async def test_parse_llm_output_stage4_fallback_guesses_python() -> None:
@@ -458,3 +457,41 @@ async def test_parse_llm_output_empty_returns_none() -> None:
     assert await parse_llm_output(None, None, "m", "") is None
     assert await parse_llm_output(None, None, "m", "   \n  ") is None
     assert await parse_llm_output(None, None, "m", None) is None  # type: ignore[arg-type]
+
+
+async def test_parse_llm_output_rejects_refusal_prose() -> None:
+    content = "I'm sorry, but I can't help with that request."
+    assert await parse_llm_output(None, None, "dummy-model", content) is None
+
+
+async def test_parse_llm_output_unwraps_markdown_wrapped_code() -> None:
+    # A prose-tagged wrapper whose bare closer is really the inner block's
+    # closer: the actual answer is the python inside, not the wrapper.
+    content = "```markdown\nHere is the solution:\n\n```python\ndef main():\n    return 1\n```\n```"
+    result = await parse_llm_output(None, None, "dummy-model", content)
+    assert result is not None
+    assert result["language"] == "python"
+    assert result["code"].strip() == "def main():\n    return 1"
+    assert "Here is the solution" not in result["code"]
+
+
+async def test_parse_llm_output_four_backtick_wrapper_keeps_inner_fence() -> None:
+    # CommonMark: a longer fence run can contain a complete shorter fence.
+    # The old pattern let the inner ``` close the ```` wrapper mid-block and
+    # threw the real code away.
+    content = "````markdown\nIntro\n\n```python\nprint('hi')\n```\n\nOutro\n````"
+    result = await parse_llm_output(None, None, "dummy-model", content)
+    assert result is not None
+    assert result["language"] == "python"
+    assert result["code"].strip() == "print('hi')"
+
+
+async def test_parse_llm_output_plain_markdown_block_stays_markdown() -> None:
+    # A markdown fence with no inner code is a legitimate answer (e.g. a
+    # requested README), not a wrapper to unwrap or a refusal to reject.
+    content = "```markdown\n# My Project\n\nJust prose describing it.\n```"
+    result = await parse_llm_output(None, None, "dummy-model", content)
+    assert result is not None
+    assert result["language"] == "markdown"
+    assert result["extension"] == ".md"
+    assert "# My Project" in result["code"]

--- a/tests/unit/test_runner_truncation.py
+++ b/tests/unit/test_runner_truncation.py
@@ -1,9 +1,14 @@
-"""Unit coverage for truncation detection in the code-mode runner.
+"""Unit coverage for truncation detection and failure recording in the runner.
 
 A response cut off by the ``max_tokens`` cap arrives with real content and no
 error — it parses, saves, and scores exactly like a complete answer.  The only
 thing separating the two is ``finish_reason``, so these tests pin that the
 runner reads it and records the distinction on the result.
+
+Failure paths live here too: a mid-stream API error, a refusal that yields no
+code, or an exception after the API call must all land in ``results`` as
+``failed`` with a reason — never escape the task and leave the model absent
+from the results box.
 """
 
 from __future__ import annotations
@@ -19,17 +24,28 @@ class _NoopTracker:
     is_running = False
 
 
-def _fake_stream(usage: dict[str, Any]):
+_CODE_REPLY = "```python\nprint('hi')\n```"
+
+
+async def _run(
+    tmp_path,
+    monkeypatch,
+    usage: dict[str, Any],
+    *,
+    content: str = _CODE_REPLY,
+    stream_exc: Exception | None = None,
+    output_dir_exc: Exception | None = None,
+) -> dict[str, Any]:
     async def fake_call_model_streaming(*_args: Any, **_kwargs: Any) -> tuple[str, dict]:
-        return "```python\nprint('hi')\n```", usage
+        if stream_exc is not None:
+            raise stream_exc
+        return content, usage
 
-    return fake_call_model_streaming
-
-
-async def _run(tmp_path, monkeypatch, usage: dict[str, Any]) -> dict[str, Any]:
-    monkeypatch.setattr(runner_mod, "call_model_streaming", _fake_stream(usage))
+    monkeypatch.setattr(runner_mod, "call_model_streaming", fake_call_model_streaming)
 
     async def output_dir() -> str:
+        if output_dir_exc is not None:
+            raise output_dir_exc
         return str(tmp_path)
 
     results: dict[str, Any] = {}
@@ -59,6 +75,16 @@ async def test_length_finish_reason_flags_the_result_as_truncated(tmp_path, monk
     assert result["usage"]["finish_reason"] == "length"
 
 
+async def test_incomplete_finish_reason_flags_the_result_as_truncated(
+    tmp_path, monkeypatch
+) -> None:
+    # The api layer stamps "incomplete" when the SSE stream hit EOF without
+    # the [DONE] sentinel: the connection dropped and the tail may be gone.
+    result = await _run(tmp_path, monkeypatch, {"total_tokens": 10, "finish_reason": "incomplete"})
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+
+
 async def test_normal_completion_is_not_flagged(tmp_path, monkeypatch) -> None:
     result = await _run(tmp_path, monkeypatch, {"total_tokens": 42, "finish_reason": "stop"})
     assert result["status"] == "success"
@@ -69,3 +95,40 @@ async def test_missing_finish_reason_is_not_flagged(tmp_path, monkeypatch) -> No
     # Some providers omit finish_reason entirely; absence is not truncation.
     result = await _run(tmp_path, monkeypatch, {"total_tokens": 42})
     assert result["truncated"] is False
+
+
+async def test_mid_stream_error_records_failure_with_reason(tmp_path, monkeypatch) -> None:
+    # OpenRouter can accept the request (HTTP 200), stream half an answer,
+    # then send a terminal error event; api.py surfaces it as RuntimeError.
+    result = await _run(
+        tmp_path,
+        monkeypatch,
+        {},
+        stream_exc=RuntimeError("mid-stream error (502): provider unavailable"),
+    )
+    assert result["status"] == "failed"
+    assert "mid-stream error" in result["error"]
+    assert result["file"] is None
+
+
+async def test_refusal_prose_records_parse_failure_with_reason(tmp_path, monkeypatch) -> None:
+    # A refusal used to fall through extraction stage 4 and save as code —
+    # scoring the model a pass for declining the task.
+    result = await _run(
+        tmp_path, monkeypatch, {"total_tokens": 12}, content="I cannot assist with that request."
+    )
+    assert result["status"] == "failed"
+    assert "code extraction failed" in result["error"]
+    assert result["file"] is None
+
+
+async def test_post_api_failure_is_recorded_not_lost(tmp_path, monkeypatch) -> None:
+    # An exception after the API call (here: the shared output-dir task
+    # failing) used to escape the task, get swallowed by
+    # gather(return_exceptions=True), and leave the model absent from the
+    # results box — neither pass nor fail.
+    result = await _run(
+        tmp_path, monkeypatch, {"total_tokens": 5}, output_dir_exc=OSError("disk full")
+    )
+    assert result["status"] == "failed"
+    assert "disk full" in result["error"]

--- a/wavebench/api.py
+++ b/wavebench/api.py
@@ -728,6 +728,7 @@ async def call_model_streaming(
                     return None, {}, resp.status, err
                 else:
                     buf = ""
+                    saw_done = False
                     content_stream = resp.content
                     while True:
                         if not _got_first_token:
@@ -758,9 +759,27 @@ async def call_model_streaming(
                                 continue
                             payload = line[6:].strip()
                             if payload == "[DONE]":
+                                saw_done = True
                                 continue
                             try:
                                 obj = json.loads(payload)
+                                # OpenRouter can accept the request (HTTP 200),
+                                # stream part of an answer, then deliver a
+                                # terminal error event with no choices at all.
+                                # Ignoring it would return the partial content
+                                # as if it were the whole answer.
+                                err_obj = obj.get("error")
+                                if isinstance(err_obj, dict) and err_obj:
+                                    err_code = err_obj.get("code")
+                                    err_msg = str(
+                                        err_obj.get("message") or ""
+                                    ).strip() or json.dumps(err_obj)
+                                    label = (
+                                        f"mid-stream error ({err_code})"
+                                        if err_code
+                                        else "mid-stream error"
+                                    )
+                                    raise RuntimeError(f"{label}: {err_msg[:200]}")
                                 if "usage" in obj:
                                     usage = obj["usage"]
                                 for ch in obj.get("choices", []):
@@ -793,6 +812,13 @@ async def call_model_streaming(
                                 pass
                     if finish_reason:
                         usage = {**usage, "finish_reason": finish_reason}
+                    elif not saw_done:
+                        # EOF with neither a finish_reason nor the [DONE]
+                        # sentinel: the connection dropped mid-generation and
+                        # the tail of the answer may be missing.  Surface it
+                        # through the same channel as max_tokens truncation so
+                        # the runner flags the file instead of passing it.
+                        usage = {**usage, "finish_reason": "incomplete"}
                     return "".join(parts), usage, 200, ""
             finally:
                 await resp_ctx.__aexit__(None, None, None)

--- a/wavebench/core/orchestrator.py
+++ b/wavebench/core/orchestrator.py
@@ -383,7 +383,30 @@ async def main_async(
                 )
 
             tasks = [_run_model_task(name, mid) for name, mid in targets]
-            await asyncio.gather(*tasks, return_exceptions=True)
+            task_errors = await asyncio.gather(*tasks, return_exceptions=True)
+            # run_model records its own failures, so a leaked exception here
+            # means a task died before writing its result.  Backstop it —
+            # a model must never be silently absent from the results box.
+            for (name, _mid), err in zip(targets, task_errors, strict=True):
+                if not isinstance(err, BaseException) or name in results:
+                    continue
+                if isinstance(err, asyncio.CancelledError):
+                    results[name] = {
+                        "status": "cancelled",
+                        "time_s": 0.0,
+                        "file": None,
+                        "usage": {},
+                        "retries": [],
+                    }
+                else:
+                    results[name] = {
+                        "status": "failed",
+                        "time_s": 0.0,
+                        "file": None,
+                        "usage": {},
+                        "retries": [],
+                        "error": str(err) or err.__class__.__name__,
+                    }
 
             if image_mode and output_dir_task.done():
                 out = output_dir_task.result()
@@ -499,7 +522,11 @@ async def main_async(
                 detail = f"{S.DIM}cancelled{S.RST}"
             else:
                 sym = _fail
-                detail = f"{S.RED}failed{S.RST}{cost_s}"
+                err = str(info.get("error") or "")
+                err_s = (
+                    f"  {S.DIM}{_truncate(err, max(12, inner_w - pad - 30))}{S.RST}" if err else ""
+                )
+                detail = f"{S.RED}failed{S.RST}{err_s}{cost_s}"
             rank = f"{S.DIM}{i:>2}.{S.RST}"
             content = f"{rank} {sym} {_rpad(name, pad)}  {detail}"
             if st == "success" and _vlen(content) + 2 + len(t) > inner_w:
@@ -527,20 +554,19 @@ async def main_async(
         print(_box_bot(w))
 
     # ── Record run & show lifetime analytics ───────────────────────────────
-    if not image_mode:
-        run_costs = {name: _result_cost(name, info) for name, info in results.items()}
-        record_run(
-            history,
-            user_prompt,
-            output_dir_final[0],
-            total_time,
-            results,
-            costs=run_costs,
-            reasoning_effort=raw_effort if not tts_mode else None,
-        )
-        display_analytics(
-            history, compact=True, pad=pad, sort_by=config.get("analytics_sort", "runs")
-        )
+    # Image runs included: "Every run is recorded" (README) — skipping them
+    # made image benchmarks invisible to history and lifetime analytics.
+    run_costs = {name: _result_cost(name, info) for name, info in results.items()}
+    record_run(
+        history,
+        user_prompt,
+        output_dir_final[0],
+        total_time,
+        results,
+        costs=run_costs,
+        reasoning_effort=raw_effort if not (tts_mode or image_mode) else None,
+    )
+    display_analytics(history, compact=True, pad=pad, sort_by=config.get("analytics_sort", "runs"))
     if tts_mode and output_dir_final[0]:
         from wavebench.tui.tts_player import browse_tts_outputs
 

--- a/wavebench/core/runner.py
+++ b/wavebench/core/runner.py
@@ -198,6 +198,7 @@ async def run_model(
             "file": None,
             "usage": {},
             "retries": retry_events,
+            "error": "timeout",
         }
         return
     except aiohttp.ClientError as exc:
@@ -214,6 +215,7 @@ async def run_model(
             "file": None,
             "usage": {},
             "retries": retry_events,
+            "error": f"API error: {str(exc) or exc.__class__.__name__}",
         }
         return
     except Exception as exc:
@@ -231,6 +233,7 @@ async def run_model(
             "file": None,
             "usage": {},
             "retries": retry_events,
+            "error": exc_str,
         }
         return
     finally:
@@ -252,6 +255,7 @@ async def run_model(
             "file": None,
             "usage": {},
             "retries": retry_events,
+            "error": "no response",
         }
         return
 
@@ -278,6 +282,7 @@ async def run_model(
                     "file": None,
                     "usage": usage,
                     "retries": retry_events,
+                    "error": "no valid base64 image data URLs",
                 }
                 return
 
@@ -328,10 +333,11 @@ async def run_model(
 
         if not parsed.parse_ok:
             elapsed = time.monotonic() - start
+            parse_reason = parsed.parse_error or "parse failed"
             if not registered:
                 print(
                     f"  {_fail} {model_name:<{pad}}  "
-                    f"{S.RED}parse failed{S.RST}  "
+                    f"{S.RED}parse failed{S.RST} {S.DIM}({parse_reason}){S.RST}  "
                     f"{S.DIM}[{format_duration(elapsed)}]{S.RST}"
                 )
             results[model_name] = {
@@ -340,6 +346,7 @@ async def run_model(
                 "file": None,
                 "usage": usage,
                 "retries": retry_events,
+                "error": parse_reason,
             }
             return
 
@@ -384,11 +391,13 @@ async def run_model(
         # mid-token, so the file on disk stops partway through.  It parses
         # and saves like any other result, which is exactly why it needs
         # calling out — otherwise it only shows up when the file won't run.
-        truncated = (usage or {}).get("finish_reason") == "length"
+        # "incomplete" is the streaming layer's marker for a connection that
+        # dropped before the [DONE] sentinel — same symptom, different cause.
+        finish = (usage or {}).get("finish_reason")
+        truncated = finish in ("length", "incomplete")
         if not registered:
-            warn = (
-                f"  {S.YEL}⚠ truncated — hit the output token cap{S.RST}" if truncated else ""
-            )
+            why = "hit the output token cap" if finish == "length" else "stream ended early"
+            warn = f"  {S.YEL}⚠ truncated — {why}{S.RST}" if truncated else ""
             print(
                 f"  {_ok} {S.BOLD}{model_name:<{pad}}{S.RST}  "
                 f"saved {_arrow} {S.GRN}{filename}{S.RST}{warn}  "
@@ -405,6 +414,41 @@ async def run_model(
         if mode.name == "code":
             result["venv_python"] = venv_python
         results[model_name] = result
+    except asyncio.CancelledError:
+        elapsed = time.monotonic() - start
+        if not registered:
+            print(
+                f"  {_skip} {model_name:<{pad}}  "
+                f"{S.DIM}cancelled  [{format_duration(elapsed)}]{S.RST}"
+            )
+        results[model_name] = {
+            "status": "cancelled",
+            "time_s": elapsed,
+            "file": None,
+            "usage": usage,
+            "retries": retry_events,
+        }
+    except Exception as exc:
+        # Without this handler, an exception after the API call (the shared
+        # output-dir task failing, a file write erroring) escaped the task,
+        # was swallowed by gather(return_exceptions=True), and the model
+        # simply vanished from the results box — neither pass nor fail.
+        elapsed = time.monotonic() - start
+        exc_str = str(exc) or exc.__class__.__name__
+        if not registered:
+            print(
+                f"  {_fail} {model_name:<{pad}}  "
+                f"{S.RED}{exc_str}{S.RST}  "
+                f"{S.DIM}[{format_duration(elapsed)}]{S.RST}"
+            )
+        results[model_name] = {
+            "status": "failed",
+            "time_s": elapsed,
+            "file": None,
+            "usage": usage,
+            "retries": retry_events,
+            "error": exc_str,
+        }
     finally:
         if registered:
             tracker.finish_parsing(model_name)

--- a/wavebench/modes/image.py
+++ b/wavebench/modes/image.py
@@ -8,6 +8,7 @@ text ignored.
 from __future__ import annotations
 
 import base64
+import hashlib
 import html
 import json
 import os
@@ -18,8 +19,10 @@ from typing import Any
 from wavebench.modes import ParsedOutput
 from wavebench.tui.styles import THEMES
 
+# The payload class is whitespace-tolerant (\s, not just \r\n) because some
+# providers hard-wrap base64 with indented continuation lines.
 _IMAGE_DATA_URL_RE = re.compile(
-    r"data:(image/[A-Za-z0-9.+-]+);base64,([A-Za-z0-9+/=\r\n]+)",
+    r"data:(image/[A-Za-z0-9.+-]+);base64,([A-Za-z0-9+/=\s]+)",
     re.IGNORECASE,
 )
 
@@ -101,16 +104,49 @@ def _detect_mime_from_bytes(data: bytes) -> str | None:
     return None
 
 
+def _is_complete_container(mime: str, data: bytes) -> bool:
+    """True when the container's end-of-file marker is present.
+
+    ``b64decode`` happily decodes any 4-char-aligned prefix of a longer
+    payload, so a stream cut mid-image still yields bytes with valid magic.
+    The trailer is the only cheap signal that the whole image arrived.
+    """
+    if mime == "image/png":
+        return data.endswith(b"IEND\xae\x42\x60\x82")
+    if mime == "image/jpeg":
+        return data.endswith(b"\xff\xd9")
+    if mime == "image/gif":
+        return data.endswith(b";")
+    if mime == "image/webp":
+        return len(data) >= 8 + int.from_bytes(data[4:8], "little")
+    return True
+
+
 def _decode_data_url(mime_type: str, payload: str) -> DecodedImage | None:
-    cleaned = "".join(payload.split())
-    try:
-        data = base64.b64decode(cleaned, validate=True)
-    except Exception:
+    chunks = payload.split()
+    if not chunks:
         return None
-    if not data:
-        return None
-    mime = _detect_mime_from_bytes(data) or mime_type.lower()
-    return DecodedImage(data=data, mime_type=mime, extension=_extension_for_mime(mime))
+    joined = "".join(chunks)
+    # The whitespace-tolerant payload class can swallow prose that follows a
+    # bare data URL ("...ggg== Enjoy!"), so when the full cleaned payload
+    # doesn't hold up, fall back to the first whitespace-delimited run.
+    candidates = [joined] if joined == chunks[0] else [joined, chunks[0]]
+    for candidate in candidates:
+        try:
+            data = base64.b64decode(candidate, validate=True)
+        except Exception:
+            continue
+        if not data:
+            continue
+        detected = _detect_mime_from_bytes(data)
+        # Only trust bytes whose magic identified a real container when that
+        # container is complete; a payload cut mid-stream decodes cleanly but
+        # saves as a corrupt file that would score the model a pass.
+        if detected is not None and not _is_complete_container(detected, data):
+            continue
+        mime = detected or mime_type.lower()
+        return DecodedImage(data=data, mime_type=mime, extension=_extension_for_mime(mime))
+    return None
 
 
 def _extract_from_string(value: str) -> list[DecodedImage]:
@@ -128,12 +164,20 @@ def extract_image_outputs(response: Any) -> list[DecodedImage]:
     OpenRouter normalizes generated images as data URLs in the assistant
     message. Providers can place them under ``message.images``, inside a
     multimodal ``content`` array, or in text-like fields, so this walks the
-    response recursively and ignores all non-image text.
+    response recursively and ignores all non-image text. The same image often
+    appears in several of those fields at once, so results are deduplicated
+    by content hash.
     """
     images: list[DecodedImage] = []
+    seen: set[bytes] = set()
 
     def add_from_string(text: str) -> None:
-        images.extend(_extract_from_string(text))
+        for decoded in _extract_from_string(text):
+            digest = hashlib.sha256(decoded.data).digest()
+            if digest in seen:
+                continue
+            seen.add(digest)
+            images.append(decoded)
 
     def walk(value: Any) -> None:
         if isinstance(value, str):

--- a/wavebench/parsers.py
+++ b/wavebench/parsers.py
@@ -7,6 +7,8 @@
     Stage 3. Salvage from an unclosed fence.
     Stage 4. Treat the whole response as code, with language guessed
              from syntactic markers (shebang, DOCTYPE, ``def``, etc.).
+             A response with no marker at all is prose (typically a
+             refusal) and fails extraction rather than passing as code.
 
 ``get_directory_name()`` derives a concise ``snake_case`` directory name from
     the user's prompt, either through the configured LLM fallback chain or a
@@ -115,10 +117,19 @@ async def get_directory_name(
     return "benchmark_output"
 
 
+# CommonMark-style fences: opener and closer both anchored to line start,
+# closed by the same run of backticks/tildes.  The old pattern terminated on
+# a bare mid-text ``\1``, so the *inner* fence of a nested block (e.g. a
+# ```python example inside a ```markdown reply) closed the outer one and the
+# actual code was thrown away.
 _FENCE_RE = re.compile(
-    r"(```|~~~)\s*([^\n`]*)\n(.*?)\n\1",
+    r"(?m)^(`{3,}|~{3,})[ \t]*([^\n]*)\n(.*?)^\1[ \t]*$",
     re.DOTALL,
 )
+
+# Fence languages that mark prose rather than code.  A block tagged with one
+# of these is usually a document wrapper around the real answer.
+_PROSE_LANGS = ("markdown", "md", "text", "txt")
 
 _LANG_TO_EXT = {
     "python": ".py",
@@ -222,7 +233,9 @@ def _salvage_unclosed_fence(text: str) -> tuple[str, str] | None:
         return None
     lang = (m.group(2) or "").split()[0].lower() if (m.group(2) or "").strip() else ""
     code = (m.group(3) or "").strip()
-    if not code:
+    # A body that is only fence punctuation/whitespace (e.g. the tail of an
+    # empty ``` ``` pair) is not salvageable code.
+    if not code or not re.sub(r"[`~\s]+", "", code):
         return None
     return lang, code
 
@@ -332,6 +345,19 @@ def extract_code(content: str) -> dict[str, Any] | None:
             non_json_blocks = [b for b in blocks if b[0] not in ("json", "")]
             candidate_blocks = non_json_blocks if non_json_blocks else blocks
             lang, code = max(candidate_blocks, key=lambda item: len(item[1].strip()))
+            if lang in _PROSE_LANGS:
+                # A prose-tagged block is usually a wrapper; the real answer
+                # may be a fence inside it.  Only take the inner result when
+                # it actually narrowed to something that isn't prose — a
+                # whole-body echo means there was no inner code, and the
+                # block stands on its own (e.g. a requested README).
+                inner = extract_code(code)
+                if (
+                    inner is not None
+                    and inner["language"] not in _PROSE_LANGS
+                    and inner["code"].strip() != code.strip()
+                ):
+                    return inner
             return _build_parse_result(code, language_hint=lang)
 
         # Stage 3: recover from malformed/unclosed fence.
@@ -341,7 +367,14 @@ def extract_code(content: str) -> dict[str, Any] | None:
             return _build_parse_result(code, language_hint=lang)
 
         # Stage 4: final fallback — treat the full response as code-like text.
-        return _build_parse_result(content.strip())
+        result = _build_parse_result(content.strip())
+        if result["language"] == "text":
+            # No fence, no JSON payload, and no syntactic code marker in the
+            # whole response: this is prose — typically a refusal — and
+            # saving it as `model.py` would score the model a pass for
+            # declining the task.
+            return None
+        return result
     except Exception as exc:
         exc_str = str(exc) or exc.__class__.__name__
         print(f"    {_tri} {S.DIM}local parse error: {exc_str}{S.RST}")

--- a/wavebench/tui/progress/tracker.py
+++ b/wavebench/tui/progress/tracker.py
@@ -428,7 +428,13 @@ class ProgressTracker:
             fname = ""
         else:
             sym = _fail
-            detail = f"{S.RED}failed{S.RST}{cost_s}{retry_s}"
+            err = str(info.get("error") or "")
+            err_s = (
+                f"  {S.DIM}{_truncate(err, max(12, inner_w - self._pad - 30))}{S.RST}"
+                if err
+                else ""
+            )
+            detail = f"{S.RED}failed{S.RST}{err_s}{cost_s}{retry_s}"
             fname = ""
         rank_s = f"{S.DIM}{rank:>2}.{S.RST}"
         content = f"{rank_s} {sym} {_rpad(name, self._pad)}  {detail}"


### PR DESCRIPTION
Closes #18.

A model that refuses, gets cut off mid-stream, returns nested-fence prose, or hits a write error now appears in the results box as **failed** with a reason — never absent, never a pass.

## The five paths

1. **Mid-stream SSE errors / dropped connections** (`wavebench/api.py`) — OpenRouter can accept a request (HTTP 200), stream part of an answer, then send a terminal `error` event with no `choices`. That now raises a `RuntimeError` carrying the provider's code and message instead of returning the partial text as the whole answer. Separately, EOF without the `[DONE]` sentinel (and no `finish_reason`) stamps `finish_reason: "incomplete"`, which the runner surfaces through the existing truncation warning as "stream ended early".
2. **Refusals scored as code** (`wavebench/parsers.py`) — stage 4 no longer saves marker-free prose as `model.py`. A response with no fence, no JSON payload, and no syntactic code marker fails extraction with a reason.
3. **Nested fences** (`wavebench/parsers.py`) — the fence regex is CommonMark-anchored (opener and closer at line start, closer a bare run of the same character), so an inner ```` ```python ```` no longer closes an outer ```` ```markdown ```` wrapper. Prose-tagged wrapper blocks recurse to the code inside, while a legitimately requested markdown document still saves as markdown.
4. **Vanishing models** (`wavebench/core/runner.py`, `wavebench/core/orchestrator.py`, `wavebench/tui/progress/tracker.py`) — exceptions after the API call (the shared output-dir task failing, a file write erroring) are caught and recorded as `failed` with the message. The `gather(return_exceptions=True)` result is now inspected as a backstop, so a task that dies before recording still lands in the results box and history. Both the tracker box and the fallback box print the failure reason next to `failed`.
5. **Corrupt/duplicate images** (`wavebench/modes/image.py`) — `b64decode` happily decodes any 4-char-aligned prefix of a longer payload, so magic bytes alone can't prove an image arrived whole. Container trailers (PNG `IEND`, JPEG `\xff\xd9`, GIF `;`, WEBP RIFF length) are now verified whenever the magic identified the container, so a truncated payload fails instead of saving a corrupt file. Identical images surfaced through multiple response fields are deduped by content hash, hard-wrapped base64 decodes, and image runs are recorded in history like every other mode (per `README.md` — "every run is recorded").

## Tests

21 new regression tests; 430 total, all passing.

- `tests/integration/test_api_streaming.py` — mid-stream error event raises; EOF without `[DONE]` → `incomplete`; `finish_reason` without `[DONE]` stays unflagged; `[DONE]` without `finish_reason` stays unflagged (all against the real aiohttp SSE test server).
- `tests/unit/test_runner_truncation.py` — `"incomplete"` flags truncation; mid-stream error, refusal prose, and post-API write failure each record `failed` with a reason.
- `tests/unit/test_orchestrator_backstop.py` (new) — a task that dies before recording is backstopped into history, and the results box shows the reason.
- `tests/unit/test_parsers.py` — refusal rejection; markdown-wrapped and 4-backtick-wrapped code unwrap to the inner code; a plain markdown README still passes as markdown.
- `tests/unit/test_modes.py` — truncated vs complete PNG/JPEG/GIF/WEBP containers; dedup across fields; hard-wrapped base64; recovery when prose follows a bare data URL.
- Rewrote the two tests that pinned the old behavior (stage-4 prose fallback; image runs skipping history).

To see it live: run a benchmark with a prompt models tend to refuse, or an image run — refusals and truncated images now show as `failed (code extraction failed — no recognizable code block)` / `failed (no valid base64 image data URLs)` in the results box, and the image run lands in `--query-history`.

Note: `ruff check` (5 errors) and `ruff format --check` fail on this branch only in code untouched here — that drift predates the branch and is fixed by #27. This PR's own hunks are lint- and format-clean, so once #27 lands, CI passes on the merge.
