### PR TITLE
Make history writes atomic, locked, and loud about corruption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,11 @@ benchmarkResults/
 .symphony/
 .DS_Store
 .benchmark_history.json
+.benchmark_history.json.*
 .benchmark_config.json
+.benchmark_config.json.*
 .benchmark_models.json
+.benchmark_models.json.*
 .benchmark_query_history
 .benchmark_query_history.*
 build/

--- a/tests/unit/test_main_clear_history.py
+++ b/tests/unit/test_main_clear_history.py
@@ -1,0 +1,63 @@
+"""Unit coverage for ``--clear-history``.
+
+The flag used to ``os.remove`` the file outright: a permission error meant
+an unhandled traceback, and every recorded run vanished with no copy kept.
+It now renames to ``.bak`` and reports failures tidily.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from wavebench import __main__ as main_mod
+
+
+def _run_clear_history(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.argv", ["wavebench", "--clear-history"])
+    main_mod.main()
+
+
+def test_clear_history_keeps_a_bak_copy(
+    tmp_state_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = {"version": 1, "runs": [{"prompt": "precious"}]}
+    (tmp_state_dir / ".benchmark_history.json").write_text(json.dumps(payload))
+
+    _run_clear_history(monkeypatch)
+
+    assert not (tmp_state_dir / ".benchmark_history.json").exists()
+    backup = tmp_state_dir / ".benchmark_history.json.bak"
+    assert json.loads(backup.read_text()) == payload
+    assert "History cleared" in capsys.readouterr().out
+
+
+def test_clear_history_reports_a_failed_rename_tidily(
+    tmp_state_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    (tmp_state_dir / ".benchmark_history.json").write_text('{"version": 1, "runs": []}')
+
+    def denied(*_args: object, **_kwargs: object) -> None:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(main_mod.os, "replace", denied)
+
+    _run_clear_history(monkeypatch)  # must not raise
+
+    assert "Could not clear history" in capsys.readouterr().out
+    assert (tmp_state_dir / ".benchmark_history.json").exists()
+
+
+def test_clear_history_with_no_history_says_so(
+    tmp_state_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _run_clear_history(monkeypatch)
+    assert "No history to clear" in capsys.readouterr().out

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -10,6 +10,7 @@ state is touched.
 from __future__ import annotations
 
 import json
+import threading
 from pathlib import Path
 
 import pytest
@@ -110,15 +111,38 @@ def test_save_history_then_load_history_roundtrip(tmp_state_dir: Path) -> None:
     assert storage.load_history() == {"version": 1, "runs": [{"prompt": "hi"}]}
 
 
-def test_load_history_without_runs_key_returns_empty(tmp_state_dir: Path) -> None:
-    # Dict without the "runs" key — treated as invalid and defaulted.
+def test_load_history_without_runs_key_quarantines_and_defaults(
+    tmp_state_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Dict without the "runs" key — invalid, so it is moved aside rather than
+    # left in place where the next save would overwrite it.
     (tmp_state_dir / ".benchmark_history.json").write_text('{"version": 1}')
     assert storage.load_history() == {"version": 1, "runs": []}
+    assert list(tmp_state_dir.glob(".benchmark_history.json.corrupt.*"))
+    assert "unreadable" in capsys.readouterr().out
 
 
-def test_load_history_corrupted_json_returns_empty(tmp_state_dir: Path) -> None:
-    (tmp_state_dir / ".benchmark_history.json").write_text("not json")
+def test_load_history_corrupted_json_quarantines_the_file(
+    tmp_state_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # A Ctrl-C mid-save used to leave truncated JSON that the next run would
+    # silently replace with a fresh single-run file. The corpse is now moved
+    # aside with a warning so nothing is destroyed.
+    truncated = '{"version": 1, "runs": [{"pro'
+    (tmp_state_dir / ".benchmark_history.json").write_text(truncated)
+
     assert storage.load_history() == {"version": 1, "runs": []}
+
+    assert not (tmp_state_dir / ".benchmark_history.json").exists()
+    corpses = list(tmp_state_dir.glob(".benchmark_history.json.corrupt.*"))
+    assert len(corpses) == 1
+    assert corpses[0].read_text() == truncated
+    assert "unreadable" in capsys.readouterr().out
+
+    # A later run starts a fresh history without touching the quarantined copy.
+    storage.record_run(prompt="fresh", output_dir="", total_time=1.0, model_results={})
+    assert corpses[0].read_text() == truncated
+    assert storage.load_history()["runs"][0]["prompt"] == "fresh"
 
 
 # ---------------------------------------------------------------------------
@@ -127,7 +151,6 @@ def test_load_history_corrupted_json_returns_empty(tmp_state_dir: Path) -> None:
 
 
 def test_record_run_appends_and_persists(tmp_state_dir: Path) -> None:
-    history: dict = {"version": 1, "runs": []}
     results = {
         "claudeOpus4.6": {
             "status": "ok",
@@ -136,8 +159,7 @@ def test_record_run_appends_and_persists(tmp_state_dir: Path) -> None:
             "usage": {"prompt_tokens": 10, "completion_tokens": 40},
         },
     }
-    storage.record_run(
-        history,
+    history = storage.record_run(
         prompt="make a snake game",
         output_dir="benchmarkResults/snake_game",
         total_time=13.7,
@@ -146,7 +168,7 @@ def test_record_run_appends_and_persists(tmp_state_dir: Path) -> None:
         reasoning_effort="high",
     )
 
-    # In-memory append is reflected.
+    # The updated history is returned for immediate display.
     assert len(history["runs"]) == 1
     run = history["runs"][0]
     assert run["prompt"] == "make a snake game"
@@ -162,10 +184,8 @@ def test_record_run_appends_and_persists(tmp_state_dir: Path) -> None:
 
 
 def test_record_run_omits_cost_when_none(tmp_state_dir: Path) -> None:
-    history: dict = {"version": 1, "runs": []}
     results = {"m": {"status": "fail", "time_s": 1.0, "file": None, "usage": {}}}
-    storage.record_run(
-        history,
+    history = storage.record_run(
         prompt="x",
         output_dir="",
         total_time=1.0,
@@ -176,9 +196,7 @@ def test_record_run_omits_cost_when_none(tmp_state_dir: Path) -> None:
 
 
 def test_record_run_omits_reasoning_effort_when_unset(tmp_state_dir: Path) -> None:
-    history: dict = {"version": 1, "runs": []}
-    storage.record_run(
-        history,
+    history = storage.record_run(
         prompt="x",
         output_dir=None,
         total_time=1.0,
@@ -189,9 +207,7 @@ def test_record_run_omits_reasoning_effort_when_unset(tmp_state_dir: Path) -> No
 
 
 def test_record_run_handles_output_dir_none(tmp_state_dir: Path) -> None:
-    history: dict = {"version": 1, "runs": []}
-    storage.record_run(
-        history,
+    history = storage.record_run(
         prompt="x",
         output_dir=None,
         total_time=0.5,
@@ -199,6 +215,89 @@ def test_record_run_handles_output_dir_none(tmp_state_dir: Path) -> None:
     )
     # None collapses to empty string per current contract.
     assert history["runs"][0]["output_dir"] == ""
+
+
+def test_record_run_appends_to_latest_on_disk_history(tmp_state_dir: Path) -> None:
+    # A second WaveBench in the same directory recorded a run while this one
+    # was mid-benchmark. record_run re-reads the file at write time, so the
+    # stale snapshot loaded at run start can never clobber the newer run.
+    storage.save_history({"version": 1, "runs": [{"prompt": "other terminal"}]})
+    history = storage.record_run(prompt="mine", output_dir="", total_time=1.0, model_results={})
+    assert [r["prompt"] for r in history["runs"]] == ["other terminal", "mine"]
+    on_disk = json.loads((tmp_state_dir / ".benchmark_history.json").read_text())
+    assert on_disk == history
+
+
+def test_record_run_waits_for_the_history_lock(tmp_state_dir: Path) -> None:
+    fcntl = pytest.importorskip("fcntl")
+    done = threading.Event()
+
+    def worker() -> None:
+        storage.record_run(prompt="locked", output_dir="", total_time=1.0, model_results={})
+        done.set()
+
+    with open(tmp_state_dir / ".benchmark_history.json.lock", "w") as holder:
+        fcntl.flock(holder.fileno(), fcntl.LOCK_EX)
+        thread = threading.Thread(target=worker, daemon=True)
+        thread.start()
+        blocked = not done.wait(0.2)
+    # Closing the descriptor releases the flock.
+    assert blocked, "record_run should wait for the lock, not race past it"
+    assert done.wait(5.0), "record_run should complete once the lock is free"
+    thread.join(timeout=5.0)
+    assert storage.load_history()["runs"][0]["prompt"] == "locked"
+
+
+def test_record_run_still_records_without_fcntl(
+    tmp_state_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Windows has no fcntl; locking degrades to none but recording must work.
+    monkeypatch.setattr(storage, "fcntl", None)
+    history = storage.record_run(prompt="x", output_dir="", total_time=1.0, model_results={})
+    assert history["runs"][0]["prompt"] == "x"
+    on_disk = json.loads((tmp_state_dir / ".benchmark_history.json").read_text())
+    assert on_disk == history
+
+
+# ---------------------------------------------------------------------------
+# Atomic writes — an interrupt mid-save must never truncate the previous file.
+# ---------------------------------------------------------------------------
+
+
+def test_save_history_interrupted_mid_write_keeps_previous_file(
+    tmp_state_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    storage.save_history({"version": 1, "runs": [{"prompt": "precious"}]})
+
+    def interrupted_dump(obj, fh, **kwargs) -> None:
+        fh.write('{"version": 1, "ru')  # a few bytes land, then Ctrl-C
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(storage.json, "dump", interrupted_dump)
+    with pytest.raises(KeyboardInterrupt):
+        storage.save_history({"version": 1, "runs": []})
+
+    on_disk = json.loads((tmp_state_dir / ".benchmark_history.json").read_text())
+    assert on_disk["runs"][0]["prompt"] == "precious"
+    assert not (tmp_state_dir / ".benchmark_history.json.tmp").exists()
+
+
+def test_save_config_interrupted_mid_write_keeps_previous_file(
+    tmp_state_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A truncated config used to silently revert every setting to defaults.
+    storage.save_config({"theme": "plum"})
+
+    def interrupted_dump(obj, fh, **kwargs) -> None:
+        fh.write('{"the')
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(storage.json, "dump", interrupted_dump)
+    with pytest.raises(KeyboardInterrupt):
+        storage.save_config({"theme": "default"})
+
+    assert storage.load_config()["theme"] == "plum"
+    assert not (tmp_state_dir / ".benchmark_config.json.tmp").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/wavebench/__main__.py
+++ b/wavebench/__main__.py
@@ -202,8 +202,13 @@ def main() -> None:
     if args.clear_history:
         path = _history_path()
         if os.path.exists(path):
-            os.remove(path)
-            print(f"\n  {_ok} History cleared.\n")
+            try:
+                os.replace(path, path + ".bak")
+            except OSError as exc:
+                print(f"\n  {_fail} Could not clear history: {exc}\n")
+                return
+            kept = os.path.basename(path) + ".bak"
+            print(f"\n  {_ok} History cleared. {S.DIM}(previous history kept as {kept}){S.RST}\n")
         else:
             print(f"\n  {S.DIM}No history to clear.{S.RST}\n")
         return

--- a/wavebench/core/orchestrator.py
+++ b/wavebench/core/orchestrator.py
@@ -298,6 +298,8 @@ async def main_async(
     output_dir_final = [None]
     t0 = time.monotonic()
 
+    # Read-only snapshot for token-average pacing hints; record_run re-reads
+    # fresh under a lock at write time, so this stale copy is never written back.
     history = load_history()
     avg_tokens: dict[str, float] = {}
     for run in history.get("runs", []):
@@ -557,8 +559,7 @@ async def main_async(
     # Image runs included: "Every run is recorded" (README) — skipping them
     # made image benchmarks invisible to history and lifetime analytics.
     run_costs = {name: _result_cost(name, info) for name, info in results.items()}
-    record_run(
-        history,
+    history = record_run(
         user_prompt,
         output_dir_final[0],
         total_time,

--- a/wavebench/storage.py
+++ b/wavebench/storage.py
@@ -10,16 +10,32 @@ Load functions fall back to defaults on missing or corrupted files so a
 clean startup always works; save functions swallow IOError and report to
 stdout so a read-only disk never aborts a run mid-flight.
 
+Saves write a sibling ``.tmp`` file, fsync it, and ``os.replace`` it over
+the target, so an interrupt mid-write can never truncate what is already
+on disk.  ``record_run`` is the only history mutator: it re-reads the file
+under an exclusive ``flock`` before appending, so concurrent runs in the
+same directory append to each other's history instead of clobbering it.
+A history file that no longer parses is quarantined to
+``.corrupt.<timestamp>`` with a warning rather than silently overwritten
+by the next save.
+
 Paths are computed from ``os.getcwd()`` at call time, which is what makes
 tests isolate correctly via ``monkeypatch.chdir(tmp_path)``.
 """
 
 import json
 import os
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager, suppress
 from datetime import datetime, timezone
 from typing import Any
 
 from wavebench.tui.styles import S, _tri
+
+try:  # fcntl is POSIX-only; without it locking degrades gracefully (saves stay atomic)
+    import fcntl
+except ImportError:  # pragma: no cover — Windows
+    fcntl = None  # type: ignore[assignment]
 
 HISTORY_FILE: str = ".benchmark_history.json"
 MODELS_FILE: str = ".benchmark_models.json"
@@ -36,6 +52,30 @@ def _models_path() -> str:
 
 def _config_path() -> str:
     return os.path.join(os.getcwd(), CONFIG_FILE)
+
+
+def _atomic_write_json(path: str, payload: Any) -> None:
+    """Write *payload* to *path* so readers never observe a partial file.
+
+    ``open(path, "w")`` truncates before the first byte lands, so an
+    interrupt mid-``json.dump`` used to leave truncated JSON behind.
+    Writing a sibling tmp file, fsyncing, and ``os.replace``-ing is atomic
+    on POSIX: the old file stays intact until the new one is durably
+    complete.
+    """
+    tmp = f"{path}.tmp"
+    replaced = False
+    try:
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+        replaced = True
+    finally:
+        if not replaced:
+            with suppress(OSError):
+                os.remove(tmp)
 
 
 def load_models() -> dict[str, str] | None:
@@ -55,8 +95,7 @@ def load_models() -> dict[str, str] | None:
 def save_models(models: dict[str, str]) -> None:
     """Persist the model selection to disk."""
     try:
-        with open(_models_path(), "w", encoding="utf-8") as fh:
-            json.dump(models, fh, indent=2)
+        _atomic_write_json(_models_path(), models)
     except OSError as exc:
         print(f"    {_tri} {S.DIM}could not save models: {exc}{S.RST}")
 
@@ -93,22 +132,44 @@ def load_config() -> dict[str, Any]:
 def save_config(config: dict[str, Any]) -> None:
     """Persist the configuration to disk."""
     try:
-        with open(_config_path(), "w", encoding="utf-8") as fh:
-            json.dump(config, fh, indent=2)
+        _atomic_write_json(_config_path(), config)
     except OSError as exc:
         print(f"    {_tri} {S.DIM}could not save config: {exc}{S.RST}")
 
 
+def _quarantine_history(path: str, reason: str) -> None:
+    """Move an unreadable history file aside so the next save cannot destroy it."""
+    print(f"\n    {_tri} {S.HYEL}analytics history is unreadable ({reason}){S.RST}")
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    target = f"{path}.corrupt.{stamp}"
+    try:
+        os.replace(path, target)
+    except OSError as exc:
+        print(f"      {S.YEL}could not move it aside ({exc}) — it may get overwritten{S.RST}")
+        return
+    kept = os.path.basename(target)
+    print(f"      {S.YEL}kept the file as {kept} — new runs start a fresh history{S.RST}")
+
+
 def load_history() -> dict[str, Any]:
-    """Load the analytics history from disk."""
+    """Load the analytics history from disk.
+
+    A file that exists but cannot be parsed is quarantined rather than
+    ignored: returning a fresh history while the broken file stays in
+    place would let the next save silently overwrite every run it still
+    holds.
+    """
     path = _history_path()
     if os.path.exists(path):
         try:
             with open(path, encoding="utf-8") as fh:
                 data = json.load(fh)
-                if isinstance(data, dict) and "runs" in data:
-                    return data
-        except (OSError, json.JSONDecodeError):
+            if isinstance(data, dict) and "runs" in data:
+                return data
+            _quarantine_history(path, "unrecognized structure")
+        except json.JSONDecodeError as exc:
+            _quarantine_history(path, f"invalid JSON at line {exc.lineno}")
+        except OSError:
             pass
     return {"version": 1, "runs": []}
 
@@ -116,22 +177,44 @@ def load_history() -> dict[str, Any]:
 def save_history(history: dict[str, Any]) -> None:
     """Persist the analytics history to disk."""
     try:
-        with open(_history_path(), "w", encoding="utf-8") as fh:
-            json.dump(history, fh, indent=2)
+        _atomic_write_json(_history_path(), history)
     except OSError as exc:
         print(f"    {_tri} {S.DIM}could not save history: {exc}{S.RST}")
 
 
+@contextmanager
+def _history_lock() -> Iterator[None]:
+    """Hold an exclusive advisory lock around a history read-modify-write.
+
+    The lock lives on a sidecar ``.lock`` file rather than the history file
+    itself because ``os.replace`` swaps the history inode — a lock taken on
+    the old inode would not exclude the next writer.  ``flock`` releases on
+    close (including process death), so a crashed run cannot wedge it.
+    Best-effort: without ``fcntl`` or with an unwritable directory, the
+    caller proceeds unlocked, which matches the pre-lock behavior.
+    """
+    with ExitStack() as stack:
+        if fcntl is not None:
+            with suppress(OSError):
+                lock_fh = stack.enter_context(open(_history_path() + ".lock", "w"))
+                fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        yield
+
+
 def record_run(
-    history: dict[str, Any],
     prompt: str,
     output_dir: str | None,
     total_time: float,
     model_results: dict[str, Any],
     costs: dict[str, float | None] | None = None,
     reasoning_effort: str | None = None,
-) -> None:
-    """Append the results of a benchmark run to *history* and save.
+) -> dict[str, Any]:
+    """Append one benchmark run to the on-disk history and return the result.
+
+    The only mutator of the history file.  It re-reads the file fresh under
+    an exclusive lock before appending, so a run that spent twenty minutes
+    benchmarking cannot write its stale start-of-run snapshot back over
+    whatever other processes recorded in the meantime.
 
     *reasoning_effort* is stamped on the record when provided so lifetime
     analytics can later stratify runs by the effort level in force — past
@@ -156,5 +239,8 @@ def record_run(
             for name, info in model_results.items()
         },
     }
-    history["runs"].append(run)
-    save_history(history)
+    with _history_lock():
+        history = load_history()
+        history["runs"].append(run)
+        save_history(history)
+    return history


### PR DESCRIPTION
Closes #19.

> Stacked on #28 (base branch `fix/18-false-passes`) because both PRs edit the `record_run` call site in `orchestrator.py`; branching from `main` would have guaranteed a merge conflict. GitHub retargets this PR to `main` automatically once #28 merges and its branch is deleted. Only commit(s) after `381cb38` are new here.

One Ctrl-C at the wrong moment could truncate the entire lifetime analytics file, and the next run would silently overwrite the evidence. This lands option 1 from the issue (tmp + fsync + `os.replace`) plus the "either way" hardening; the append-only JSONL migration (option 2) stays available as a follow-up — the O(n) rewrite cost it addresses is measured-negligible today, and rotation policy deserves its own discussion.

## What changed

1. **Atomic saves** (`wavebench/storage.py`) — history, models, and config all write to a sibling `.tmp`, `fsync`, then `os.replace` over the target. An interrupt mid-write now leaves the previous complete file untouched (and no stray `.tmp`). This also protects the 0-byte-config-reverts-all-settings and 0-byte-models-reverts-to-defaults failure modes called out in the issue.
2. **Corruption is quarantined, not silently discarded** (`wavebench/storage.py`) — `load_history` on unparseable JSON (or a JSON dict without `runs`) renames the file to `.corrupt.<timestamp>` and prints a loud yellow warning, then starts fresh. Previously it returned `{"version": 1, "runs": []}` silently and the next `record_run` overwrote everything the broken file still held.
3. **`record_run` is the only mutator, with a critical section** (`wavebench/storage.py`, `wavebench/core/orchestrator.py`) — it takes an exclusive `flock` on a sidecar `.lock` file (the lock can't live on the history file itself: `os.replace` swaps the inode out from under it), re-reads history fresh, appends, atomically replaces, and returns the updated history. The `history` argument threading is gone from the orchestrator, so its 20-minute-old start-of-run snapshot (kept read-only for the token-average hints) can never be written back. Locking is best-effort: no `fcntl` (Windows) or an unwritable directory degrades to today's unlocked behavior instead of blocking the run.
4. **`--clear-history` keeps a copy and fails tidily** (`wavebench/__main__.py`) — `os.replace(path, path + ".bak")` inside `try/except OSError` instead of bare `os.remove`, so a permission error prints `✗ Could not clear history: …` instead of a traceback, and the runs survive as `.bak`.
5. `.gitignore` — the three state-file entries gained `.*` globs so the new sidecar files (`.tmp`, `.lock`, `.corrupt.<ts>`, `.bak`) never show up in `git status`.

## Tests

8 new/rewritten regression tests; 438 total, all passing.

- `tests/unit/test_storage.py` — interrupt (KeyboardInterrupt with partial bytes written) mid-`save_history`/`save_config` keeps the previous file and leaves no `.tmp`; corrupt JSON is quarantined with the original bytes preserved and later runs don't touch the corpse; `record_run` appends to the latest on-disk history rather than a stale snapshot; `record_run` genuinely blocks on a held `flock` and completes when it's released; recording still works with `fcntl` absent (Windows path).
- `tests/unit/test_main_clear_history.py` (new) — `--clear-history` through the real `main()`: keeps a readable `.bak`, reports a failed rename tidily without raising, and still says "No history to clear" when empty.

## Verified live

- 5 concurrent `record_run` processes in one directory → 5/5 runs recorded (lost-update before).
- Hand-truncated history + next load → loud warning, file preserved as `.benchmark_history.json.corrupt.20260726-182131`.
- Real `python -m wavebench --clear-history` → `✓ History cleared. (previous history kept as .benchmark_history.json.bak)`, backup content intact.

Note: repo-wide `ruff check` (5 errors) and `ruff format --check` still fail on this branch only in code untouched here — that drift predates the branch and is fixed by #27. Every file this PR touches is lint- and format-clean.
